### PR TITLE
fix: add missing ColumnExprs method to table descriptor

### DIFF
--- a/internal/codegen/descriptorcodegen/table.go
+++ b/internal/codegen/descriptorcodegen/table.go
@@ -58,6 +58,7 @@ func (g TableDescriptorCodeGenerator) generateInterface(f *codegen.File) {
 	f.P(g.TableIDMethod(), "() ", spansqlPkg, ".ID")
 	f.P(g.ColumnNamesMethod(), "() []string")
 	f.P(g.ColumnIDsMethod(), "() []", spansqlPkg, ".ID")
+	f.P(g.ColumnExprsMethod(), "() []", spansqlPkg, ".Expr")
 	for _, column := range g.Table.Columns {
 		f.P(g.ColumnDescriptorMethod(column), "() ", genericColumnDescriptor.InterfaceType())
 	}

--- a/internal/codegen/descriptorcodegen/testdata/1.sql.database.go
+++ b/internal/codegen/descriptorcodegen/testdata/1.sql.database.go
@@ -59,6 +59,7 @@ type SingersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor

--- a/internal/codegen/descriptorcodegen/testdata/1.sql.table.go
+++ b/internal/codegen/descriptorcodegen/testdata/1.sql.table.go
@@ -13,6 +13,7 @@ type SingersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor

--- a/internal/codegen/descriptorcodegen/testdata/2.sql.database.go
+++ b/internal/codegen/descriptorcodegen/testdata/2.sql.database.go
@@ -86,6 +86,7 @@ type SingersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor
@@ -156,6 +157,7 @@ type AlbumsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	AlbumId() ColumnDescriptor
 	AlbumTitle() ColumnDescriptor

--- a/internal/codegen/descriptorcodegen/testdata/2.sql.table.go
+++ b/internal/codegen/descriptorcodegen/testdata/2.sql.table.go
@@ -13,6 +13,7 @@ type SingersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor
@@ -83,6 +84,7 @@ type AlbumsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	AlbumId() ColumnDescriptor
 	AlbumTitle() ColumnDescriptor

--- a/internal/examples/freightdb/descriptor_gen.go
+++ b/internal/examples/freightdb/descriptor_gen.go
@@ -240,6 +240,7 @@ type ShippersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	ShipperId() ColumnDescriptor
 	CreateTime() ColumnDescriptor
 	UpdateTime() ColumnDescriptor
@@ -310,6 +311,7 @@ type SitesTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	ShipperId() ColumnDescriptor
 	SiteId() ColumnDescriptor
 	CreateTime() ColumnDescriptor
@@ -416,6 +418,7 @@ type ShipmentsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	ShipperId() ColumnDescriptor
 	ShipmentId() ColumnDescriptor
 	CreateTime() ColumnDescriptor
@@ -549,6 +552,7 @@ type LineItemsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	ShipperId() ColumnDescriptor
 	ShipmentId() ColumnDescriptor
 	LineNumber() ColumnDescriptor

--- a/internal/examples/musicdb/descriptor_gen.go
+++ b/internal/examples/musicdb/descriptor_gen.go
@@ -117,6 +117,7 @@ type SingersTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor
@@ -187,6 +188,7 @@ type AlbumsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	AlbumId() ColumnDescriptor
 	AlbumTitle() ColumnDescriptor
@@ -248,6 +250,7 @@ type SongsTableDescriptor interface {
 	TableID() spansql.ID
 	ColumnNames() []string
 	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
 	AlbumId() ColumnDescriptor
 	TrackId() ColumnDescriptor


### PR DESCRIPTION
Struct has the implementation but the interface is missing the
declaration, so it's not accessible via the public API.
