### PR TITLE
fix: hide deleted interleaved rows by default

### DIFF
--- a/internal/codegen/databasecodegen/testdata/2.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/2.sql.database.go
@@ -527,11 +527,12 @@ SELECT
 FROM
     Singers
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -543,13 +544,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &SingersRowIterator{

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -743,11 +743,12 @@ SELECT
 FROM
     Singers
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -759,13 +760,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &SingersRowIterator{
@@ -996,11 +997,12 @@ SELECT
 FROM
     Albums
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -1012,13 +1014,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &AlbumsRowIterator{

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -958,11 +958,12 @@ SELECT
 FROM
     Singers
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -974,13 +975,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &SingersRowIterator{
@@ -1213,11 +1214,12 @@ SELECT
 FROM
     Albums
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -1229,13 +1231,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &AlbumsRowIterator{

--- a/internal/codegen/databasecodegen/testdata/6.sql
+++ b/internal/codegen/databasecodegen/testdata/6.sql
@@ -4,3 +4,12 @@ CREATE TABLE shippers (
     update_time TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
     delete_time TIMESTAMP OPTIONS (allow_commit_timestamp=true),
 ) PRIMARY KEY(shipper_id);
+
+CREATE TABLE shipments (
+    shipper_id STRING(63) NOT NULL,
+    shipment_id STRING(63) NOT NULL,
+    create_time TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    update_time TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    delete_time TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY(shipper_id, shipment_id),
+  INTERLEAVE IN PARENT shippers ON DELETE CASCADE;

--- a/internal/codegen/databasecodegen/testdata/6.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/6.sql.database.go
@@ -7,10 +7,14 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type ShippersRow struct {
@@ -18,6 +22,7 @@ type ShippersRow struct {
 	CreateTime time.Time        `spanner:"create_time"`
 	UpdateTime time.Time        `spanner:"update_time"`
 	DeleteTime spanner.NullTime `spanner:"delete_time"`
+	Shipments  []*ShipmentsRow  `spanner:"shipments"`
 }
 
 func (*ShippersRow) ColumnNames() []string {
@@ -73,6 +78,10 @@ func (r *ShippersRow) UnmarshalSpannerRow(row *spanner.Row) error {
 			if err := row.Column(i, &r.DeleteTime); err != nil {
 				return fmt.Errorf("unmarshal shippers row: delete_time column: %w", err)
 			}
+		case "shipments":
+			if err := row.Column(i, &r.Shipments); err != nil {
+				return fmt.Errorf("unmarshal shippers interleaved row: shipments column: %w", err)
+			}
 		default:
 			return fmt.Errorf("unmarshal shippers row: unhandled column: %s", row.ColumnName(i))
 		}
@@ -117,6 +126,125 @@ func (r *ShippersRow) Key() ShippersKey {
 	}
 }
 
+type ShipmentsRow struct {
+	ShipperId  string           `spanner:"shipper_id"`
+	ShipmentId string           `spanner:"shipment_id"`
+	CreateTime time.Time        `spanner:"create_time"`
+	UpdateTime time.Time        `spanner:"update_time"`
+	DeleteTime spanner.NullTime `spanner:"delete_time"`
+}
+
+func (*ShipmentsRow) ColumnNames() []string {
+	return []string{
+		"shipper_id",
+		"shipment_id",
+		"create_time",
+		"update_time",
+		"delete_time",
+	}
+}
+
+func (*ShipmentsRow) ColumnIDs() []spansql.ID {
+	return []spansql.ID{
+		"shipper_id",
+		"shipment_id",
+		"create_time",
+		"update_time",
+		"delete_time",
+	}
+}
+
+func (*ShipmentsRow) ColumnExprs() []spansql.Expr {
+	return []spansql.Expr{
+		spansql.ID("shipper_id"),
+		spansql.ID("shipment_id"),
+		spansql.ID("create_time"),
+		spansql.ID("update_time"),
+		spansql.ID("delete_time"),
+	}
+}
+
+func (r *ShipmentsRow) Validate() error {
+	if len(r.ShipperId) > 63 {
+		return fmt.Errorf("column shipper_id length > 63")
+	}
+	if len(r.ShipmentId) > 63 {
+		return fmt.Errorf("column shipment_id length > 63")
+	}
+	return nil
+}
+
+func (r *ShipmentsRow) UnmarshalSpannerRow(row *spanner.Row) error {
+	for i := 0; i < row.Size(); i++ {
+		switch row.ColumnName(i) {
+		case "shipper_id":
+			if err := row.Column(i, &r.ShipperId); err != nil {
+				return fmt.Errorf("unmarshal shipments row: shipper_id column: %w", err)
+			}
+		case "shipment_id":
+			if err := row.Column(i, &r.ShipmentId); err != nil {
+				return fmt.Errorf("unmarshal shipments row: shipment_id column: %w", err)
+			}
+		case "create_time":
+			if err := row.Column(i, &r.CreateTime); err != nil {
+				return fmt.Errorf("unmarshal shipments row: create_time column: %w", err)
+			}
+		case "update_time":
+			if err := row.Column(i, &r.UpdateTime); err != nil {
+				return fmt.Errorf("unmarshal shipments row: update_time column: %w", err)
+			}
+		case "delete_time":
+			if err := row.Column(i, &r.DeleteTime); err != nil {
+				return fmt.Errorf("unmarshal shipments row: delete_time column: %w", err)
+			}
+		default:
+			return fmt.Errorf("unmarshal shipments row: unhandled column: %s", row.ColumnName(i))
+		}
+	}
+	return nil
+}
+
+func (r *ShipmentsRow) Mutate() (string, []string, []interface{}) {
+	return "shipments", r.ColumnNames(), []interface{}{
+		r.ShipperId,
+		r.ShipmentId,
+		r.CreateTime,
+		r.UpdateTime,
+		r.DeleteTime,
+	}
+}
+
+func (r *ShipmentsRow) MutateColumns(columns []string) (string, []string, []interface{}) {
+	if len(columns) == 0 {
+		columns = r.ColumnNames()
+	}
+	values := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		switch column {
+		case "shipper_id":
+			values = append(values, r.ShipperId)
+		case "shipment_id":
+			values = append(values, r.ShipmentId)
+		case "create_time":
+			values = append(values, r.CreateTime)
+		case "update_time":
+			values = append(values, r.UpdateTime)
+		case "delete_time":
+			values = append(values, r.DeleteTime)
+		default:
+			panic(fmt.Errorf("table shipments does not have column %s", column))
+		}
+	}
+	return "shipments", columns, values
+}
+
+func (r *ShipmentsRow) Key() ShipmentsKey {
+	return ShipmentsKey{
+		ShipperId:  r.ShipperId,
+		ShipmentId: r.ShipmentId,
+	}
+}
+
 type ShippersKey struct {
 	ShipperId string
 }
@@ -150,6 +278,51 @@ func (k ShippersKey) BoolExpr() spansql.BoolExpr {
 	return spansql.Paren{Expr: b}
 }
 
+type ShipmentsKey struct {
+	ShipperId  string
+	ShipmentId string
+}
+
+func (k ShipmentsKey) SpannerKey() spanner.Key {
+	return spanner.Key{
+		k.ShipperId,
+		k.ShipmentId,
+	}
+}
+
+func (k ShipmentsKey) SpannerKeySet() spanner.KeySet {
+	return k.SpannerKey()
+}
+
+func (k ShipmentsKey) Delete() *spanner.Mutation {
+	return spanner.Delete("shipments", k.SpannerKey())
+}
+
+func (ShipmentsKey) Order() []spansql.Order {
+	return []spansql.Order{
+		{Expr: spansql.ID("shipper_id"), Desc: false},
+		{Expr: spansql.ID("shipment_id"), Desc: false},
+	}
+}
+
+func (k ShipmentsKey) BoolExpr() spansql.BoolExpr {
+	b := spansql.BoolExpr(spansql.ComparisonOp{
+		Op:  spansql.Eq,
+		LHS: spansql.ID("shipper_id"),
+		RHS: spansql.StringLiteral(k.ShipperId),
+	})
+	b = spansql.LogicalOp{
+		Op:  spansql.And,
+		LHS: b,
+		RHS: spansql.ComparisonOp{
+			Op:  spansql.Eq,
+			LHS: spansql.ID("shipment_id"),
+			RHS: spansql.StringLiteral(k.ShipmentId),
+		},
+	}
+	return spansql.Paren{Expr: b}
+}
+
 type ShippersRowIterator struct {
 	*spanner.RowIterator
 }
@@ -169,6 +342,32 @@ func (i *ShippersRowIterator) Next() (*ShippersRow, error) {
 func (i *ShippersRowIterator) Do(f func(row *ShippersRow) error) error {
 	return i.RowIterator.Do(func(spannerRow *spanner.Row) error {
 		var row ShippersRow
+		if err := row.UnmarshalSpannerRow(spannerRow); err != nil {
+			return err
+		}
+		return f(&row)
+	})
+}
+
+type ShipmentsRowIterator struct {
+	*spanner.RowIterator
+}
+
+func (i *ShipmentsRowIterator) Next() (*ShipmentsRow, error) {
+	spannerRow, err := i.RowIterator.Next()
+	if err != nil {
+		return nil, err
+	}
+	var row ShipmentsRow
+	if err := row.UnmarshalSpannerRow(spannerRow); err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (i *ShipmentsRowIterator) Do(f func(row *ShipmentsRow) error) error {
+	return i.RowIterator.Do(func(spannerRow *spanner.Row) error {
+		var row ShipmentsRow
 		if err := row.UnmarshalSpannerRow(spannerRow); err != nil {
 			return err
 		}
@@ -199,13 +398,21 @@ func (t ReadTransaction) ReadShippersRows(
 }
 
 type GetShippersRowQuery struct {
-	Key ShippersKey
+	Key       ShippersKey
+	Shipments bool
+}
+
+func (q *GetShippersRowQuery) hasInterleavedTables() bool {
+	return q.Shipments
 }
 
 func (t ReadTransaction) GetShippersRow(
 	ctx context.Context,
 	query GetShippersRowQuery,
 ) (*ShippersRow, error) {
+	if query.hasInterleavedTables() {
+		return t.getShippersRowInterleaved(ctx, query)
+	}
 	spannerRow, err := t.Tx.ReadRow(
 		ctx,
 		"shippers",
@@ -223,13 +430,21 @@ func (t ReadTransaction) GetShippersRow(
 }
 
 type BatchGetShippersRowsQuery struct {
-	Keys []ShippersKey
+	Keys      []ShippersKey
+	Shipments bool
+}
+
+func (q *BatchGetShippersRowsQuery) hasInterleavedTables() bool {
+	return q.Shipments
 }
 
 func (t ReadTransaction) BatchGetShippersRows(
 	ctx context.Context,
 	query BatchGetShippersRowsQuery,
 ) (map[ShippersKey]*ShippersRow, error) {
+	if query.hasInterleavedTables() {
+		return t.batchGetShippersRowsInterleaved(ctx, query)
+	}
 	spannerKeys := make([]spanner.KeySet, 0, len(query.Keys))
 	for _, key := range query.Keys {
 		spannerKeys = append(spannerKeys, key.SpannerKey())
@@ -251,12 +466,20 @@ type ListShippersRowsQuery struct {
 	Offset      int64
 	Params      map[string]interface{}
 	ShowDeleted bool
+	Shipments   bool
+}
+
+func (q *ListShippersRowsQuery) hasInterleavedTables() bool {
+	return q.Shipments
 }
 
 func (t ReadTransaction) ListShippersRows(
 	ctx context.Context,
 	query ListShippersRowsQuery,
 ) *ShippersRowIterator {
+	if query.hasInterleavedTables() {
+		return t.listShippersRowsInterleaved(ctx, query)
+	}
 	if len(query.Order) == 0 {
 		query.Order = ShippersKey{}.Order()
 	}
@@ -299,6 +522,262 @@ func (t ReadTransaction) ListShippersRows(
 		Params: params,
 	}
 	return &ShippersRowIterator{
+		RowIterator: t.Tx.Query(ctx, stmt),
+	}
+}
+
+func (t ReadTransaction) listShippersRowsInterleaved(
+	ctx context.Context,
+	query ListShippersRowsQuery,
+) *ShippersRowIterator {
+	if len(query.Order) == 0 {
+		query.Order = ShippersKey{}.Order()
+	}
+	var q strings.Builder
+	_, _ = q.WriteString(`
+SELECT
+    shipper_id,
+    create_time,
+    update_time,
+    delete_time,
+`)
+	if query.Shipments {
+		_, _ = q.WriteString(`
+    ARRAY(
+        SELECT AS STRUCT
+            shipper_id,
+            shipment_id,
+            create_time,
+            update_time,
+            delete_time,
+`)
+		_, _ = q.WriteString(`
+        FROM 
+            shipments
+        WHERE 
+`)
+		if !query.ShowDeleted {
+			_, _ = q.WriteString(`
+            delete_time IS NULL AND
+`)
+		}
+		_, _ = q.WriteString(`
+            shipments.shipper_id = shippers.shipper_id
+        ORDER BY 
+            shipper_id,
+            shipment_id
+    ) AS shipments,
+`)
+	}
+	_, _ = q.WriteString(`
+FROM
+    shippers
+`)
+	if query.Where == nil {
+		query.Where = spansql.True
+	}
+	if !query.ShowDeleted {
+		query.Where = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: spansql.Paren{Expr: query.Where},
+			RHS: spansql.IsOp{
+				LHS: spansql.ID("delete_time"),
+				RHS: spansql.Null,
+			},
+		}
+	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
+	if len(query.Order) > 0 {
+		_, _ = q.WriteString("ORDER BY ")
+		for i, order := range query.Order {
+			_, _ = q.WriteString(order.SQL())
+			if i < len(query.Order)-1 {
+				_, _ = q.WriteString(", ")
+			} else {
+				_, _ = q.WriteString(" ")
+			}
+		}
+	}
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
+	stmt := spanner.Statement{
+		SQL: q.String(),
+		Params: map[string]interface{}{
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
+		},
+	}
+	return &ShippersRowIterator{
+		RowIterator: t.Tx.Query(ctx, stmt),
+	}
+}
+
+func (t ReadTransaction) getShippersRowInterleaved(
+	ctx context.Context,
+	query GetShippersRowQuery,
+) (*ShippersRow, error) {
+	it := t.listShippersRowsInterleaved(ctx, ListShippersRowsQuery{
+		Limit:     1,
+		Where:     query.Key.BoolExpr(),
+		Shipments: query.Shipments,
+	})
+	defer it.Stop()
+	row, err := it.Next()
+	if err != nil {
+		if err == iterator.Done {
+			return nil, status.Errorf(codes.NotFound, "not found: %v", query.Key)
+		}
+		return nil, err
+	}
+	return row, nil
+}
+
+func (t ReadTransaction) batchGetShippersRowsInterleaved(
+	ctx context.Context,
+	query BatchGetShippersRowsQuery,
+) (map[ShippersKey]*ShippersRow, error) {
+	if len(query.Keys) == 0 {
+		return nil, nil
+	}
+	where := query.Keys[0].BoolExpr()
+	for _, key := range query.Keys[1:] {
+		where = spansql.LogicalOp{
+			Op:  spansql.Or,
+			LHS: where,
+			RHS: key.BoolExpr(),
+		}
+	}
+	foundRows := make(map[ShippersKey]*ShippersRow, len(query.Keys))
+	if err := t.ListShippersRows(ctx, ListShippersRowsQuery{
+		Where:     spansql.Paren{Expr: where},
+		Limit:     int32(len(query.Keys)),
+		Shipments: query.Shipments,
+	}).Do(func(row *ShippersRow) error {
+		foundRows[row.Key()] = row
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return foundRows, nil
+}
+
+func (t ReadTransaction) ReadShipmentsRows(
+	ctx context.Context,
+	keySet spanner.KeySet,
+) *ShipmentsRowIterator {
+	return &ShipmentsRowIterator{
+		RowIterator: t.Tx.Read(
+			ctx,
+			"shipments",
+			keySet,
+			((*ShipmentsRow)(nil)).ColumnNames(),
+		),
+	}
+}
+
+type GetShipmentsRowQuery struct {
+	Key ShipmentsKey
+}
+
+func (t ReadTransaction) GetShipmentsRow(
+	ctx context.Context,
+	query GetShipmentsRowQuery,
+) (*ShipmentsRow, error) {
+	spannerRow, err := t.Tx.ReadRow(
+		ctx,
+		"shipments",
+		query.Key.SpannerKey(),
+		((*ShipmentsRow)(nil)).ColumnNames(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	var row ShipmentsRow
+	if err := row.UnmarshalSpannerRow(spannerRow); err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+type BatchGetShipmentsRowsQuery struct {
+	Keys []ShipmentsKey
+}
+
+func (t ReadTransaction) BatchGetShipmentsRows(
+	ctx context.Context,
+	query BatchGetShipmentsRowsQuery,
+) (map[ShipmentsKey]*ShipmentsRow, error) {
+	spannerKeys := make([]spanner.KeySet, 0, len(query.Keys))
+	for _, key := range query.Keys {
+		spannerKeys = append(spannerKeys, key.SpannerKey())
+	}
+	foundRows := make(map[ShipmentsKey]*ShipmentsRow, len(query.Keys))
+	if err := t.ReadShipmentsRows(ctx, spanner.KeySets(spannerKeys...)).Do(func(row *ShipmentsRow) error {
+		foundRows[row.Key()] = row
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return foundRows, nil
+}
+
+type ListShipmentsRowsQuery struct {
+	Where       spansql.BoolExpr
+	Order       []spansql.Order
+	Limit       int32
+	Offset      int64
+	Params      map[string]interface{}
+	ShowDeleted bool
+}
+
+func (t ReadTransaction) ListShipmentsRows(
+	ctx context.Context,
+	query ListShipmentsRowsQuery,
+) *ShipmentsRowIterator {
+	if len(query.Order) == 0 {
+		query.Order = ShipmentsKey{}.Order()
+	}
+	params := map[string]interface{}{
+		"__limit":  int64(query.Limit),
+		"__offset": query.Offset,
+	}
+	for param, value := range query.Params {
+		if _, ok := params[param]; ok {
+			panic(fmt.Errorf("invalid param: %s", param))
+		}
+		params[param] = value
+	}
+	if query.Where == nil {
+		query.Where = spansql.True
+	}
+	if !query.ShowDeleted {
+		query.Where = spansql.LogicalOp{
+			Op:  spansql.And,
+			LHS: spansql.Paren{Expr: query.Where},
+			RHS: spansql.IsOp{
+				LHS: spansql.ID("delete_time"),
+				RHS: spansql.Null,
+			},
+		}
+	}
+	stmt := spanner.Statement{
+		SQL: spansql.Query{
+			Select: spansql.Select{
+				List: ((*ShipmentsRow)(nil)).ColumnExprs(),
+				From: []spansql.SelectFrom{
+					spansql.SelectFromTable{Table: "shipments"},
+				},
+				Where: query.Where,
+			},
+			Order:  query.Order,
+			Limit:  spansql.Param("__limit"),
+			Offset: spansql.Param("__offset"),
+		}.SQL(),
+		Params: params,
+	}
+	return &ShipmentsRowIterator{
 		RowIterator: t.Tx.Query(ctx, stmt),
 	}
 }

--- a/internal/examples/musicdb/database_gen.go
+++ b/internal/examples/musicdb/database_gen.go
@@ -741,11 +741,12 @@ SELECT
 FROM
     Singers
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -757,13 +758,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &SingersRowIterator{
@@ -994,11 +995,12 @@ SELECT
 FROM
     Albums
 `)
-	if query.Where != nil {
-		_, _ = q.WriteString("WHERE (")
-		_, _ = q.WriteString(query.Where.SQL())
-		_, _ = q.WriteString(") ")
+	if query.Where == nil {
+		query.Where = spansql.True
 	}
+	_, _ = q.WriteString("WHERE (")
+	_, _ = q.WriteString(query.Where.SQL())
+	_, _ = q.WriteString(") ")
 	if len(query.Order) > 0 {
 		_, _ = q.WriteString("ORDER BY ")
 		for i, order := range query.Order {
@@ -1010,13 +1012,13 @@ FROM
 			}
 		}
 	}
-	_, _ = q.WriteString("LIMIT @limit ")
-	_, _ = q.WriteString("OFFSET @offset ")
+	_, _ = q.WriteString("LIMIT @__limit ")
+	_, _ = q.WriteString("OFFSET @__offset ")
 	stmt := spanner.Statement{
 		SQL: q.String(),
 		Params: map[string]interface{}{
-			"limit":  int64(query.Limit),
-			"offset": query.Offset,
+			"__limit":  int64(query.Limit),
+			"__offset": query.Offset,
 		},
 	}
 	return &AlbumsRowIterator{

--- a/testdata/migrations/freight/000003_shipments.up.sql
+++ b/testdata/migrations/freight/000003_shipments.up.sql
@@ -10,4 +10,5 @@ CREATE TABLE shipments (
     pickup_latest_time TIMESTAMP,
     delivery_earliest_time TIMESTAMP,
     delivery_latest_time TIMESTAMP,
-) PRIMARY KEY(shipper_id, shipment_id);
+) PRIMARY KEY(shipper_id, shipment_id),
+  INTERLEAVE IN PARENT shippers ON DELETE CASCADE;


### PR DESCRIPTION
If an interleaved table has a delete time, the `ShowDeleted` option will
apply also to interleaved tables.
