### PR TITLE
fix: return deleted results for interleaved Get/BatchGet

### DIFF
--- a/internal/codegen/databasecodegen/readtransaction.go
+++ b/internal/codegen/databasecodegen/readtransaction.go
@@ -165,6 +165,9 @@ func (g ReadTransactionCodeGenerator) generateGetInterleavedMethod(f *codegen.Fi
 	f.P("it := t.", g.ListInterleavedMethod(table), "(ctx, ", g.ListQueryStruct(table), "{")
 	f.P("Limit: 1,")
 	f.P("Where: query.Key.BoolExpr(),")
+	if g.hasSoftDelete(table) {
+		f.P("ShowDeleted: true,")
+	}
 	g.forwardInterleavedTablesStructFields(f, table, "query")
 	f.P("})")
 	f.P("defer it.Stop()")
@@ -480,6 +483,9 @@ func (g ReadTransactionCodeGenerator) generateBatchGetInterleavedMethod(f *codeg
 	f.P("if err := t.", g.ListMethod(table), "(ctx, ", g.ListQueryStruct(table), "{")
 	f.P("Where: ", spansqlPkg, ".Paren{Expr: where},")
 	f.P("Limit: int32(len(query.Keys)),")
+	if g.hasSoftDelete(table) {
+		f.P("ShowDeleted: true,")
+	}
 	g.forwardInterleavedTablesStructFields(f, table, "query")
 	f.P("}).Do(func(row *", row.Type(), ") error {")
 	f.P("foundRows[row.", row.KeyMethod(), "()] = row")

--- a/internal/codegen/databasecodegen/testdata/6.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/6.sql.database.go
@@ -627,9 +627,10 @@ func (t ReadTransaction) getShippersRowInterleaved(
 	query GetShippersRowQuery,
 ) (*ShippersRow, error) {
 	it := t.listShippersRowsInterleaved(ctx, ListShippersRowsQuery{
-		Limit:     1,
-		Where:     query.Key.BoolExpr(),
-		Shipments: query.Shipments,
+		Limit:       1,
+		Where:       query.Key.BoolExpr(),
+		ShowDeleted: true,
+		Shipments:   query.Shipments,
 	})
 	defer it.Stop()
 	row, err := it.Next()
@@ -659,9 +660,10 @@ func (t ReadTransaction) batchGetShippersRowsInterleaved(
 	}
 	foundRows := make(map[ShippersKey]*ShippersRow, len(query.Keys))
 	if err := t.ListShippersRows(ctx, ListShippersRowsQuery{
-		Where:     spansql.Paren{Expr: where},
-		Limit:     int32(len(query.Keys)),
-		Shipments: query.Shipments,
+		Where:       spansql.Paren{Expr: where},
+		Limit:       int32(len(query.Keys)),
+		ShowDeleted: true,
+		Shipments:   query.Shipments,
 	}).Do(func(row *ShippersRow) error {
 		foundRows[row.Key()] = row
 		return nil

--- a/internal/examples/freightdb/database_gen.go
+++ b/internal/examples/freightdb/database_gen.go
@@ -1195,10 +1195,11 @@ func (t ReadTransaction) getShippersRowInterleaved(
 	query GetShippersRowQuery,
 ) (*ShippersRow, error) {
 	it := t.listShippersRowsInterleaved(ctx, ListShippersRowsQuery{
-		Limit:     1,
-		Where:     query.Key.BoolExpr(),
-		Shipments: query.Shipments,
-		LineItems: query.LineItems,
+		Limit:       1,
+		Where:       query.Key.BoolExpr(),
+		ShowDeleted: true,
+		Shipments:   query.Shipments,
+		LineItems:   query.LineItems,
 	})
 	defer it.Stop()
 	row, err := it.Next()
@@ -1228,10 +1229,11 @@ func (t ReadTransaction) batchGetShippersRowsInterleaved(
 	}
 	foundRows := make(map[ShippersKey]*ShippersRow, len(query.Keys))
 	if err := t.ListShippersRows(ctx, ListShippersRowsQuery{
-		Where:     spansql.Paren{Expr: where},
-		Limit:     int32(len(query.Keys)),
-		Shipments: query.Shipments,
-		LineItems: query.LineItems,
+		Where:       spansql.Paren{Expr: where},
+		Limit:       int32(len(query.Keys)),
+		ShowDeleted: true,
+		Shipments:   query.Shipments,
+		LineItems:   query.LineItems,
 	}).Do(func(row *ShippersRow) error {
 		foundRows[row.Key()] = row
 		return nil
@@ -1604,9 +1606,10 @@ func (t ReadTransaction) getShipmentsRowInterleaved(
 	query GetShipmentsRowQuery,
 ) (*ShipmentsRow, error) {
 	it := t.listShipmentsRowsInterleaved(ctx, ListShipmentsRowsQuery{
-		Limit:     1,
-		Where:     query.Key.BoolExpr(),
-		LineItems: query.LineItems,
+		Limit:       1,
+		Where:       query.Key.BoolExpr(),
+		ShowDeleted: true,
+		LineItems:   query.LineItems,
 	})
 	defer it.Stop()
 	row, err := it.Next()
@@ -1636,9 +1639,10 @@ func (t ReadTransaction) batchGetShipmentsRowsInterleaved(
 	}
 	foundRows := make(map[ShipmentsKey]*ShipmentsRow, len(query.Keys))
 	if err := t.ListShipmentsRows(ctx, ListShipmentsRowsQuery{
-		Where:     spansql.Paren{Expr: where},
-		Limit:     int32(len(query.Keys)),
-		LineItems: query.LineItems,
+		Where:       spansql.Paren{Expr: where},
+		Limit:       int32(len(query.Keys)),
+		ShowDeleted: true,
+		LineItems:   query.LineItems,
 	}).Do(func(row *ShipmentsRow) error {
 		foundRows[row.Key()] = row
 		return nil


### PR DESCRIPTION
This behavior aligns more closely to AIP 164 (Soft Deletes).

See: https://google.aip.dev/164

> Get (AIP-131) requests for soft-deleted resources should return the
> resource (rather than a NOT_FOUND error).
