### PR TITLE
fix: handle nullable primary key in query API

### DIFF
--- a/internal/codegen/databasecodegen/key.go
+++ b/internal/codegen/databasecodegen/key.go
@@ -74,23 +74,26 @@ func (g KeyCodeGenerator) generateBoolExprMethod(f *codegen.File) {
 	f.P()
 	f.P("func (k ", g.Type(), ") BoolExpr() ", spansqlPkg, ".BoolExpr {")
 	for i, keyPart := range g.Table.PrimaryKey {
-		f.P("cmp", i, " := ", spansqlPkg, ".ComparisonOp{")
+		f.P("cmp", i, " := ", spansqlPkg, ".BoolExpr(", spansqlPkg, ".ComparisonOp{")
 		f.P("Op: ", spansqlPkg, ".Eq,")
 		f.P("LHS: ", spansqlPkg, ".ID(", strconv.Quote(string(keyPart.Column)), "),")
 		f.P(
 			"RHS: ", g.columnSpanSQLType(f, keyPart),
 			"(k.", g.FieldName(keyPart), typescodegen.ValueAccessor(g.keyColumn(keyPart)), "),",
 		)
-		f.P("}")
+		f.P("})")
 		if !g.keyColumn(keyPart).NotNull {
 			f.P("if !k.", g.FieldName(keyPart), ".Valid {")
-			f.P("cmp", i, ".RHS = ", spansqlPkg, ".Null")
+			f.P("cmp", i, "= ", spansqlPkg, ".IsOp{")
+			f.P("LHS: ", spansqlPkg, ".ID(", strconv.Quote(string(keyPart.Column)), "),")
+			f.P("RHS: ", spansqlPkg, ".Null,")
+			f.P("}")
 			f.P("}")
 		}
 	}
 	for i := range g.Table.PrimaryKey {
 		if i == 0 {
-			f.P("b := ", spansqlPkg, ".BoolExpr(cmp", i, ")")
+			f.P("b := cmp", i)
 		} else {
 			f.P("b = ", spansqlPkg, ".LogicalOp{")
 			f.P("Op: ", spansqlPkg, ".And,")

--- a/internal/codegen/databasecodegen/testdata/1.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/1.sql.database.go
@@ -144,12 +144,12 @@ func (SingersKey) Order() []spansql.Order {
 }
 
 func (k SingersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 

--- a/internal/codegen/databasecodegen/testdata/2.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/2.sql.database.go
@@ -244,12 +244,12 @@ func (SingersKey) Order() []spansql.Order {
 }
 
 func (k SingersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -281,17 +281,17 @@ func (AlbumsKey) Order() []spansql.Order {
 }
 
 func (k AlbumsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -352,12 +352,12 @@ func (SingersKey) Order() []spansql.Order {
 }
 
 func (k SingersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -389,17 +389,17 @@ func (AlbumsKey) Order() []spansql.Order {
 }
 
 func (k AlbumsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -439,22 +439,22 @@ func (SongsKey) Order() []spansql.Order {
 }
 
 func (k SongsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	cmp2 := spansql.ComparisonOp{
+	})
+	cmp2 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("TrackId"),
 		RHS: spansql.IntegerLiteral(k.TrackId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -460,12 +460,12 @@ func (SingersKey) Order() []spansql.Order {
 }
 
 func (k SingersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -497,17 +497,17 @@ func (AlbumsKey) Order() []spansql.Order {
 }
 
 func (k AlbumsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -547,22 +547,22 @@ func (SongsKey) Order() []spansql.Order {
 }
 
 func (k SongsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	cmp2 := spansql.ComparisonOp{
+	})
+	cmp2 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("TrackId"),
 		RHS: spansql.IntegerLiteral(k.TrackId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -607,22 +607,22 @@ func (SinglesKey) Order() []spansql.Order {
 }
 
 func (k SinglesKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	cmp2 := spansql.ComparisonOp{
+	})
+	cmp2 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingleId"),
 		RHS: spansql.IntegerLiteral(k.SingleId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/codegen/databasecodegen/testdata/5.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/5.sql.database.go
@@ -121,17 +121,17 @@ func (UserAccessLogKey) Order() []spansql.Order {
 }
 
 func (k UserAccessLogKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("UserId"),
 		RHS: spansql.IntegerLiteral(k.UserId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("LastAccess"),
 		RHS: spansql.TimestampLiteral(k.LastAccess),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/codegen/databasecodegen/testdata/6.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/6.sql.database.go
@@ -270,12 +270,12 @@ func (ShippersKey) Order() []spansql.Order {
 }
 
 func (k ShippersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -307,17 +307,17 @@ func (ShipmentsKey) Order() []spansql.Order {
 }
 
 func (k ShipmentsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipment_id"),
 		RHS: spansql.StringLiteral(k.ShipmentId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/codegen/databasecodegen/testdata/7.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/7.sql.database.go
@@ -160,20 +160,23 @@ func (ShippersKey) Order() []spansql.Order {
 }
 
 func (k ShippersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("revision_id"),
 		RHS: spansql.StringLiteral(k.RevisionId.StringVal),
-	}
+	})
 	if !k.RevisionId.Valid {
-		cmp1.RHS = spansql.Null
+		cmp1 = spansql.IsOp{
+			LHS: spansql.ID("revision_id"),
+			RHS: spansql.Null,
+		}
 	}
-	b := spansql.BoolExpr(cmp0)
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/examples/freightdb/database_gen.go
+++ b/internal/examples/freightdb/database_gen.go
@@ -645,12 +645,12 @@ func (ShippersKey) Order() []spansql.Order {
 }
 
 func (k ShippersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -682,17 +682,17 @@ func (SitesKey) Order() []spansql.Order {
 }
 
 func (k SitesKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("site_id"),
 		RHS: spansql.StringLiteral(k.SiteId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -729,17 +729,17 @@ func (ShipmentsKey) Order() []spansql.Order {
 }
 
 func (k ShipmentsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipment_id"),
 		RHS: spansql.StringLiteral(k.ShipmentId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -779,22 +779,22 @@ func (LineItemsKey) Order() []spansql.Order {
 }
 
 func (k LineItemsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipper_id"),
 		RHS: spansql.StringLiteral(k.ShipperId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("shipment_id"),
 		RHS: spansql.StringLiteral(k.ShipmentId),
-	}
-	cmp2 := spansql.ComparisonOp{
+	})
+	cmp2 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("line_number"),
 		RHS: spansql.IntegerLiteral(k.LineNumber),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,

--- a/internal/examples/musicdb/database_gen.go
+++ b/internal/examples/musicdb/database_gen.go
@@ -350,12 +350,12 @@ func (SingersKey) Order() []spansql.Order {
 }
 
 func (k SingersKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	return spansql.Paren{Expr: b}
 }
 
@@ -387,17 +387,17 @@ func (AlbumsKey) Order() []spansql.Order {
 }
 
 func (k AlbumsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,
@@ -437,22 +437,22 @@ func (SongsKey) Order() []spansql.Order {
 }
 
 func (k SongsKey) BoolExpr() spansql.BoolExpr {
-	cmp0 := spansql.ComparisonOp{
+	cmp0 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("SingerId"),
 		RHS: spansql.IntegerLiteral(k.SingerId),
-	}
-	cmp1 := spansql.ComparisonOp{
+	})
+	cmp1 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("AlbumId"),
 		RHS: spansql.IntegerLiteral(k.AlbumId),
-	}
-	cmp2 := spansql.ComparisonOp{
+	})
+	cmp2 := spansql.BoolExpr(spansql.ComparisonOp{
 		Op:  spansql.Eq,
 		LHS: spansql.ID("TrackId"),
 		RHS: spansql.IntegerLiteral(k.TrackId),
-	}
-	b := spansql.BoolExpr(cmp0)
+	})
+	b := cmp0
 	b = spansql.LogicalOp{
 		Op:  spansql.And,
 		LHS: b,


### PR DESCRIPTION
Comparing NULL values in Spanner does not work with regular `=` but
needs `IS NULL` comparator.
    
When listing interleaved table, using `a = b` when both a and b are NULL
returns a falsy value (`NULL`) leading to no rows returned.
