### PR TITLE
feat: rename aipspansql to spanordering

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
-// Package aipspanner provides primitives for implementing Spanner persistence
+// Package spanneraip is a collection of packages for implementing Spanner persistence
 // for resource-oriented APIs.
 //
 // See: https://aip.dev
-package aip
+package spanneraip

--- a/spanordering/doc.go
+++ b/spanordering/doc.go
@@ -1,0 +1,4 @@
+// Package spanordering provides primitives for transpiling AIP ordering directives to Spanner SQL.
+//
+// See: https://google.aip.dev/132#ordering
+package spanordering

--- a/spanordering/transpile.go
+++ b/spanordering/transpile.go
@@ -1,4 +1,4 @@
-package aipspansql
+package spanordering
 
 import (
 	"strings"
@@ -7,8 +7,8 @@ import (
 	"go.einride.tech/aip/ordering"
 )
 
-// Order translates a valid ordering.OrderBy expression to a spansql.Order expression.
-func Order(orderBy ordering.OrderBy) []spansql.Order {
+// TranspileOrderBy transpiles a valid ordering.OrderBy expression to a spansql.Order expression.
+func TranspileOrderBy(orderBy ordering.OrderBy) []spansql.Order {
 	if len(orderBy.Fields) == 0 {
 		return nil
 	}

--- a/spanordering/transpile_test.go
+++ b/spanordering/transpile_test.go
@@ -1,4 +1,4 @@
-package aipspansql
+package spanordering
 
 import (
 	"testing"
@@ -8,7 +8,7 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestOrder(t *testing.T) {
+func TestTranspileOrderBy(t *testing.T) {
 	t.Parallel()
 	for _, tt := range []struct {
 		name     string
@@ -74,7 +74,7 @@ func TestOrder(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.DeepEqual(t, tt.expected, Order(tt.orderBy))
+			assert.DeepEqual(t, tt.expected, TranspileOrderBy(tt.orderBy))
 		})
 	}
 }


### PR DESCRIPTION
For naming parity between the following packages:

* `spanordering` (to transpile ordering.OrderBy to Spanner SQL)
* `spanfiltering` (to transpile filtering.Filter to Spanner SQL)

BREAKING CHANGE: aipspansql.Order package has been renamed to
                 spanordering.TranspileOrderBy.
