### PR TITLE
feat(spantest): add InMemoryFixture with API-parity to emulator fixture

### DIFF
--- a/internal/examples/musicdb/database_test.go
+++ b/internal/examples/musicdb/database_test.go
@@ -1,6 +1,7 @@
 package musicdb_test
 
 import (
+	"context"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -12,7 +13,10 @@ import (
 
 func TestReadTransaction(t *testing.T) {
 	t.Parallel()
-	fx := spantest.NewEmulatorDockerFixture(t)
+	fx := spantest.NewEmulatorFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
 	t.Run("insert and get", func(t *testing.T) {
 		t.Parallel()
 		client := fx.NewDatabaseFromDDLFiles(t, "../../../testdata/migrations/music/*.up.sql")
@@ -21,11 +25,11 @@ func TestReadTransaction(t *testing.T) {
 			FirstName: spanner.NullString{StringVal: "Frank", Valid: true},
 			LastName:  spanner.NullString{StringVal: "Sinatra", Valid: true},
 		}
-		_, err := client.Apply(fx.Ctx, []*spanner.Mutation{spanner.Insert(expected.Mutate())})
+		_, err := client.Apply(ctx, []*spanner.Mutation{spanner.Insert(expected.Mutate())})
 		assert.NilError(t, err)
 		tx := client.Single()
 		defer tx.Close()
-		actual, err := musicdb.Query(tx).GetSingersRow(fx.Ctx, musicdb.GetSingersRowQuery{
+		actual, err := musicdb.Query(tx).GetSingersRow(ctx, musicdb.GetSingersRowQuery{
 			Key: expected.Key(),
 		})
 		assert.NilError(t, err)
@@ -46,7 +50,7 @@ func TestReadTransaction(t *testing.T) {
 		singers := make([]*musicdb.SingersRow, 0, n)
 		for i := 0; i < n; i++ {
 			singer := newSinger(i)
-			_, err := client.Apply(fx.Ctx, []*spanner.Mutation{spanner.Insert(singer.Mutate())})
+			_, err := client.Apply(ctx, []*spanner.Mutation{spanner.Insert(singer.Mutate())})
 			assert.NilError(t, err)
 			singers = append(singers, singer)
 		}
@@ -57,7 +61,7 @@ func TestReadTransaction(t *testing.T) {
 		}
 		tx := client.Single()
 		defer tx.Close()
-		actual, err := musicdb.Query(tx).BatchGetSingersRows(fx.Ctx, musicdb.BatchGetSingersRowsQuery{
+		actual, err := musicdb.Query(tx).BatchGetSingersRows(ctx, musicdb.BatchGetSingersRowsQuery{
 			Keys: []musicdb.SingersKey{
 				singers[1].Key(),
 				singers[3].Key(),
@@ -83,7 +87,7 @@ func TestReadTransaction(t *testing.T) {
 		expected := make([]*musicdb.SingersRow, 0, n)
 		for i := 0; i < n; i++ {
 			singer := newSinger(i)
-			_, err := client.Apply(fx.Ctx, []*spanner.Mutation{spanner.Insert(singer.Mutate())})
+			_, err := client.Apply(ctx, []*spanner.Mutation{spanner.Insert(singer.Mutate())})
 			assert.NilError(t, err)
 			expected = append(expected, singer)
 		}
@@ -92,7 +96,7 @@ func TestReadTransaction(t *testing.T) {
 		tx := client.ReadOnlyTransaction()
 		defer tx.Close()
 		for i := int64(0); i < n/pageSize; i++ {
-			assert.NilError(t, musicdb.Query(tx).ListSingersRows(fx.Ctx, musicdb.ListSingersRowsQuery{
+			assert.NilError(t, musicdb.Query(tx).ListSingersRows(ctx, musicdb.ListSingersRowsQuery{
 				Order: []spansql.Order{
 					{Expr: musicdb.Descriptor().Singers().SingerId().ColumnID()},
 				},
@@ -105,75 +109,18 @@ func TestReadTransaction(t *testing.T) {
 		}
 		assert.DeepEqual(t, expected, actual)
 	})
-}
 
-func TestReadTransaction_interleaved(t *testing.T) {
-	t.Parallel()
-	if !spantest.HasDocker() {
-		t.Skip("Need Docker to run Spanner emulator.")
-	}
-	fx := spantest.NewEmulatorDockerFixture(t)
-
-	t.Run("insert and get", func(t *testing.T) {
-		t.Parallel()
-		client := fx.NewDatabaseFromDDLFiles(t, "../../../testdata/migrations/music/*.up.sql")
-		expected := &musicdb.SingersRow{
-			SingerId:  1,
-			FirstName: spanner.NullString{StringVal: "Frank", Valid: true},
-			LastName:  spanner.NullString{StringVal: "Sinatra", Valid: true},
-			Albums: []*musicdb.AlbumsRow{
-				{
-					SingerId: 1,
-					AlbumId:  1,
-					AlbumTitle: spanner.NullString{
-						StringVal: "Test1",
-						Valid:     true,
-					},
-				},
-				{
-					SingerId: 1,
-					AlbumId:  2,
-					AlbumTitle: spanner.NullString{
-						StringVal: "Test2",
-						Valid:     true,
-					},
-				},
-				{
-					SingerId: 1,
-					AlbumId:  3,
-					AlbumTitle: spanner.NullString{
-						StringVal: "Test3",
-						Valid:     true,
-					},
-				},
-			},
-		}
-		mutations := []*spanner.Mutation{spanner.Insert(expected.Mutate())}
-		for _, album := range expected.Albums {
-			mutations = append(mutations, spanner.Insert(album.Mutate()))
-		}
-		_, err := client.Apply(fx.Ctx, mutations)
-		assert.NilError(t, err)
-		tx := client.Single()
-		actual, err := musicdb.Query(tx).GetSingersRow(fx.Ctx, musicdb.GetSingersRowQuery{
-			Key:    expected.Key(),
-			Albums: true,
-		})
-		assert.NilError(t, err)
-		assert.DeepEqual(t, expected, actual)
-	})
-
-	t.Run("insert and batch get", func(t *testing.T) {
-		t.Parallel()
-		client := fx.NewDatabaseFromDDLFiles(t, "../../../testdata/migrations/music/*.up.sql")
-		newSingerAndAlbums := func(i int) *musicdb.SingersRow {
-			return &musicdb.SingersRow{
-				SingerId:  int64(i),
+	t.Run("interleaved", func(t *testing.T) {
+		t.Run("insert and get", func(t *testing.T) {
+			t.Parallel()
+			client := fx.NewDatabaseFromDDLFiles(t, "../../../testdata/migrations/music/*.up.sql")
+			expected := &musicdb.SingersRow{
+				SingerId:  1,
 				FirstName: spanner.NullString{StringVal: "Frank", Valid: true},
 				LastName:  spanner.NullString{StringVal: "Sinatra", Valid: true},
 				Albums: []*musicdb.AlbumsRow{
 					{
-						SingerId: int64(i),
+						SingerId: 1,
 						AlbumId:  1,
 						AlbumTitle: spanner.NullString{
 							StringVal: "Test1",
@@ -181,7 +128,7 @@ func TestReadTransaction_interleaved(t *testing.T) {
 						},
 					},
 					{
-						SingerId: int64(i),
+						SingerId: 1,
 						AlbumId:  2,
 						AlbumTitle: spanner.NullString{
 							StringVal: "Test2",
@@ -189,7 +136,7 @@ func TestReadTransaction_interleaved(t *testing.T) {
 						},
 					},
 					{
-						SingerId: int64(i),
+						SingerId: 1,
 						AlbumId:  3,
 						AlbumTitle: spanner.NullString{
 							StringVal: "Test3",
@@ -198,35 +145,86 @@ func TestReadTransaction_interleaved(t *testing.T) {
 					},
 				},
 			}
-		}
-		const n = 10
-		singersAndAlbums := make([]*musicdb.SingersRow, 0, n)
-		for i := 0; i < n; i++ {
-			singerAndAlbums := newSingerAndAlbums(i)
-			mutations := []*spanner.Mutation{spanner.Insert(singerAndAlbums.Mutate())}
-			for _, album := range singerAndAlbums.Albums {
+			mutations := []*spanner.Mutation{spanner.Insert(expected.Mutate())}
+			for _, album := range expected.Albums {
 				mutations = append(mutations, spanner.Insert(album.Mutate()))
 			}
-			_, err := client.Apply(fx.Ctx, mutations)
+			_, err := client.Apply(ctx, mutations)
 			assert.NilError(t, err)
-			singersAndAlbums = append(singersAndAlbums, singerAndAlbums)
-		}
-		expected := map[musicdb.SingersKey]*musicdb.SingersRow{
-			singersAndAlbums[1].Key(): singersAndAlbums[1],
-			singersAndAlbums[3].Key(): singersAndAlbums[3],
-			singersAndAlbums[5].Key(): singersAndAlbums[5],
-		}
-		tx := client.Single()
-		actual, err := musicdb.Query(tx).BatchGetSingersRows(fx.Ctx, musicdb.BatchGetSingersRowsQuery{
-			Keys: []musicdb.SingersKey{
-				singersAndAlbums[1].Key(),
-				singersAndAlbums[3].Key(),
-				singersAndAlbums[5].Key(),
-				{SingerId: n + 1}, // not found
-			},
-			Albums: true,
+			tx := client.Single()
+			actual, err := musicdb.Query(tx).GetSingersRow(ctx, musicdb.GetSingersRowQuery{
+				Key:    expected.Key(),
+				Albums: true,
+			})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, expected, actual)
 		})
-		assert.NilError(t, err)
-		assert.DeepEqual(t, expected, actual)
+
+		t.Run("insert and batch get", func(t *testing.T) {
+			t.Parallel()
+			client := fx.NewDatabaseFromDDLFiles(t, "../../../testdata/migrations/music/*.up.sql")
+			newSingerAndAlbums := func(i int) *musicdb.SingersRow {
+				return &musicdb.SingersRow{
+					SingerId:  int64(i),
+					FirstName: spanner.NullString{StringVal: "Frank", Valid: true},
+					LastName:  spanner.NullString{StringVal: "Sinatra", Valid: true},
+					Albums: []*musicdb.AlbumsRow{
+						{
+							SingerId: int64(i),
+							AlbumId:  1,
+							AlbumTitle: spanner.NullString{
+								StringVal: "Test1",
+								Valid:     true,
+							},
+						},
+						{
+							SingerId: int64(i),
+							AlbumId:  2,
+							AlbumTitle: spanner.NullString{
+								StringVal: "Test2",
+								Valid:     true,
+							},
+						},
+						{
+							SingerId: int64(i),
+							AlbumId:  3,
+							AlbumTitle: spanner.NullString{
+								StringVal: "Test3",
+								Valid:     true,
+							},
+						},
+					},
+				}
+			}
+			const n = 10
+			singersAndAlbums := make([]*musicdb.SingersRow, 0, n)
+			for i := 0; i < n; i++ {
+				singerAndAlbums := newSingerAndAlbums(i)
+				mutations := []*spanner.Mutation{spanner.Insert(singerAndAlbums.Mutate())}
+				for _, album := range singerAndAlbums.Albums {
+					mutations = append(mutations, spanner.Insert(album.Mutate()))
+				}
+				_, err := client.Apply(ctx, mutations)
+				assert.NilError(t, err)
+				singersAndAlbums = append(singersAndAlbums, singerAndAlbums)
+			}
+			expected := map[musicdb.SingersKey]*musicdb.SingersRow{
+				singersAndAlbums[1].Key(): singersAndAlbums[1],
+				singersAndAlbums[3].Key(): singersAndAlbums[3],
+				singersAndAlbums[5].Key(): singersAndAlbums[5],
+			}
+			tx := client.Single()
+			actual, err := musicdb.Query(tx).BatchGetSingersRows(ctx, musicdb.BatchGetSingersRowsQuery{
+				Keys: []musicdb.SingersKey{
+					singersAndAlbums[1].Key(),
+					singersAndAlbums[3].Key(),
+					singersAndAlbums[5].Key(),
+					{SingerId: n + 1}, // not found
+				},
+				Albums: true,
+			})
+			assert.NilError(t, err)
+			assert.DeepEqual(t, expected, actual)
+		})
 	})
 }

--- a/spantest/fixture.go
+++ b/spantest/fixture.go
@@ -1,0 +1,15 @@
+package spantest
+
+import (
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+// Fixture is a Spanner test fixture.
+type Fixture interface {
+	// NewDatabaseFromDLLFiles creates a new database and applies the DDL files from the provided glob.
+	NewDatabaseFromDDLFiles(t *testing.T, glob string) *spanner.Client
+	// NewDatabaseFromStatements creates a new database and applies the provided DLL statements.
+	NewDatabaseFromStatements(t *testing.T, statements []string) *spanner.Client
+}

--- a/spantest/inmemory.go
+++ b/spantest/inmemory.go
@@ -1,0 +1,79 @@
+package spantest
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"cloud.google.com/go/spanner/spannertest"
+	"cloud.google.com/go/spanner/spansql"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"gotest.tools/v3/assert"
+)
+
+// InMemoryFixture is a test fixture running the Spanner emulator.
+type InMemoryFixture struct {
+	ctx context.Context
+}
+
+// NewInMemoryFixture creates a test fixture for the in-memory Spanner emulator.
+func NewInMemoryFixture(t *testing.T) Fixture {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if deadline, ok := t.Deadline(); ok {
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+	}
+	return &InMemoryFixture{ctx: ctx}
+}
+
+// NewDatabaseFromDDLFiles implements Fixture.
+func (fx *InMemoryFixture) NewDatabaseFromDDLFiles(t *testing.T, glob string) *spanner.Client {
+	t.Helper()
+	files, err := filepath.Glob(glob)
+	assert.NilError(t, err)
+	var statements []string
+	for _, file := range files {
+		content, err := ioutil.ReadFile(file)
+		assert.NilError(t, err)
+		ddl, err := spansql.ParseDDL(file, string(content))
+		assert.NilError(t, err)
+		for _, ddlStmt := range ddl.List {
+			statements = append(statements, ddlStmt.SQL())
+		}
+	}
+	assert.Assert(t, len(statements) > 0)
+	return fx.NewDatabaseFromStatements(t, statements)
+}
+
+// NewDatabaseFromDDLFiles implements Fixture.
+func (fx *InMemoryFixture) NewDatabaseFromStatements(t *testing.T, statements []string) *spanner.Client {
+	t.Helper()
+	const (
+		projectID  = "spanner-aip-go"
+		instanceID = "in-memory"
+	)
+	databaseID := "db" + strconv.Itoa(rand.Int()) // nolint: gosec
+	databaseName := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instanceID, databaseID)
+	server, err := spannertest.NewServer("localhost:0")
+	assert.NilError(t, err)
+	t.Cleanup(server.Close)
+	conn, err := grpc.Dial(server.Addr, grpc.WithInsecure())
+	assert.NilError(t, err)
+	client, err := spanner.NewClient(fx.ctx, databaseName, option.WithGRPCConn(conn))
+	assert.NilError(t, err)
+	t.Cleanup(client.Close)
+	for i, statement := range statements {
+		ddl, err := spansql.ParseDDL(fmt.Sprintf("statement%d", i), statement)
+		assert.NilError(t, err)
+		assert.NilError(t, server.UpdateDDL(ddl))
+	}
+	return client
+}


### PR DESCRIPTION
To make it easier to migrate tests to-and-from using the Dockerized
emulator.
