### PR TITLE
feat!: transpile filters to expressions with parameters

### DIFF
--- a/spanfiltering/transpile.go
+++ b/spanfiltering/transpile.go
@@ -5,8 +5,10 @@ import (
 	"go.einride.tech/aip/filtering"
 )
 
-// TranspileFilter transpiles a parsed AIP filter expression to a spansql.BoolExpr.
-func TranspileFilter(filter filtering.Filter) (spansql.BoolExpr, error) {
+// TranspileFilter transpiles a parsed AIP filter expression to a spansql.BoolExpr, and
+// parameters used in the expression.
+// The parameter map is nil if the expression does not contain any parameters.
+func TranspileFilter(filter filtering.Filter) (spansql.BoolExpr, map[string]interface{}, error) {
 	var t Transpiler
 	t.Init(filter)
 	return t.Transpile()


### PR DESCRIPTION
Instead of transpiling filters to a single spansql.BoolExpr with
spansql.[...]Literal, filters are transpiled to a spansql.BoolExpr with
every literal returned as a parameter.

This fixes potential security issue where malicous filters are
transpiled directly to SQL without proper escaping.
    
Parameters are automatically named using a counter based on order of
appearance in the expr.Expr AST. This could be prettier, but atleast
provides a deterministic naming which *could* improve ability to cache
the filter (this is an assumption).
