### PR TITLE
feat: transpile has operator on repeated primitives

### DIFF
--- a/spanfiltering/transpile_test.go
+++ b/spanfiltering/transpile_test.go
@@ -78,6 +78,19 @@ func TestTranspileFilter(t *testing.T) {
 		},
 
 		{
+			name:   "has: repeated string",
+			filter: `repeated_string:"value"`,
+			declarations: []filtering.DeclarationOption{
+				filtering.DeclareStandardFunctions(),
+				filtering.DeclareIdent("repeated_string", filtering.TypeList(filtering.TypeString)),
+			},
+			expectedSQL: `(@param_0 IN UNNEST(repeated_string))`,
+			expectedParams: map[string]interface{}{
+				"param_0": "value",
+			},
+		},
+
+		{
 			name:   "empty filter",
 			filter: ``,
 			declarations: []filtering.DeclarationOption{


### PR DESCRIPTION
Implements a subset of the recommended `has` interpretations described
in https://google.aip.dev/160#has-operator.

