### PR TITLE
feat: add MutatePresentColumns method

### DIFF
--- a/internal/codegen/databasecodegen/testdata/1.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/1.sql.database.go
@@ -114,6 +114,24 @@ func (r *SingersRow) MutateColumns(columns []string) (string, []string, []interf
 	return "Singers", columns, values
 }
 
+func (r *SingersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+	)
+	if !r.FirstName.IsNull() {
+		columns = append(columns, "FirstName")
+	}
+	if !r.LastName.IsNull() {
+		columns = append(columns, "LastName")
+	}
+	if len(r.SingerInfo) != 0 {
+		columns = append(columns, "SingerInfo")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SingersRow) Key() SingersKey {
 	return SingersKey{
 		SingerId: r.SingerId,

--- a/internal/codegen/databasecodegen/testdata/2.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/2.sql.database.go
@@ -119,6 +119,24 @@ func (r *SingersRow) MutateColumns(columns []string) (string, []string, []interf
 	return "Singers", columns, values
 }
 
+func (r *SingersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+	)
+	if !r.FirstName.IsNull() {
+		columns = append(columns, "FirstName")
+	}
+	if !r.LastName.IsNull() {
+		columns = append(columns, "LastName")
+	}
+	if len(r.SingerInfo) != 0 {
+		columns = append(columns, "SingerInfo")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SingersRow) Key() SingersKey {
 	return SingersKey{
 		SingerId: r.SingerId,
@@ -207,6 +225,19 @@ func (r *AlbumsRow) MutateColumns(columns []string) (string, []string, []interfa
 		}
 	}
 	return "Albums", columns, values
+}
+
+func (r *AlbumsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+	)
+	if !r.AlbumTitle.IsNull() {
+		columns = append(columns, "AlbumTitle")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *AlbumsRow) Key() AlbumsKey {

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -119,6 +119,24 @@ func (r *SingersRow) MutateColumns(columns []string) (string, []string, []interf
 	return "Singers", columns, values
 }
 
+func (r *SingersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+	)
+	if !r.FirstName.IsNull() {
+		columns = append(columns, "FirstName")
+	}
+	if !r.LastName.IsNull() {
+		columns = append(columns, "LastName")
+	}
+	if len(r.SingerInfo) != 0 {
+		columns = append(columns, "SingerInfo")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SingersRow) Key() SingersKey {
 	return SingersKey{
 		SingerId: r.SingerId,
@@ -212,6 +230,19 @@ func (r *AlbumsRow) MutateColumns(columns []string) (string, []string, []interfa
 		}
 	}
 	return "Albums", columns, values
+}
+
+func (r *AlbumsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+	)
+	if !r.AlbumTitle.IsNull() {
+		columns = append(columns, "AlbumTitle")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *AlbumsRow) Key() AlbumsKey {
@@ -314,6 +345,20 @@ func (r *SongsRow) MutateColumns(columns []string) (string, []string, []interfac
 		}
 	}
 	return "Songs", columns, values
+}
+
+func (r *SongsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+		"TrackId",
+	)
+	if !r.SongName.IsNull() {
+		columns = append(columns, "SongName")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *SongsRow) Key() SongsKey {

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -124,6 +124,24 @@ func (r *SingersRow) MutateColumns(columns []string) (string, []string, []interf
 	return "Singers", columns, values
 }
 
+func (r *SingersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+	)
+	if !r.FirstName.IsNull() {
+		columns = append(columns, "FirstName")
+	}
+	if !r.LastName.IsNull() {
+		columns = append(columns, "LastName")
+	}
+	if len(r.SingerInfo) != 0 {
+		columns = append(columns, "SingerInfo")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SingersRow) Key() SingersKey {
 	return SingersKey{
 		SingerId: r.SingerId,
@@ -217,6 +235,19 @@ func (r *AlbumsRow) MutateColumns(columns []string) (string, []string, []interfa
 		}
 	}
 	return "Albums", columns, values
+}
+
+func (r *AlbumsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+	)
+	if !r.AlbumTitle.IsNull() {
+		columns = append(columns, "AlbumTitle")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *AlbumsRow) Key() AlbumsKey {
@@ -321,6 +352,20 @@ func (r *SongsRow) MutateColumns(columns []string) (string, []string, []interfac
 	return "Songs", columns, values
 }
 
+func (r *SongsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+		"TrackId",
+	)
+	if !r.SongName.IsNull() {
+		columns = append(columns, "SongName")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SongsRow) Key() SongsKey {
 	return SongsKey{
 		SingerId: r.SingerId,
@@ -422,6 +467,20 @@ func (r *SinglesRow) MutateColumns(columns []string) (string, []string, []interf
 		}
 	}
 	return "Singles", columns, values
+}
+
+func (r *SinglesRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+		"SingleId",
+	)
+	if !r.SongName.IsNull() {
+		columns = append(columns, "SongName")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *SinglesRow) Key() SinglesKey {

--- a/internal/codegen/databasecodegen/testdata/5.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/5.sql.database.go
@@ -87,6 +87,16 @@ func (r *UserAccessLogRow) MutateColumns(columns []string) (string, []string, []
 	return "UserAccessLog", columns, values
 }
 
+func (r *UserAccessLogRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"UserId",
+		"LastAccess",
+	)
+	return r.MutateColumns(columns)
+}
+
 func (r *UserAccessLogRow) Key() UserAccessLogKey {
 	return UserAccessLogKey{
 		UserId:     r.UserId,

--- a/internal/codegen/databasecodegen/testdata/6.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/6.sql.database.go
@@ -117,6 +117,20 @@ func (r *ShippersRow) MutateColumns(columns []string) (string, []string, []inter
 	return "shippers", columns, values
 }
 
+func (r *ShippersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *ShippersRow) Key() ShippersKey {
 	return ShippersKey{
 		ShipperId: r.ShipperId,
@@ -233,6 +247,21 @@ func (r *ShipmentsRow) MutateColumns(columns []string) (string, []string, []inte
 		}
 	}
 	return "shipments", columns, values
+}
+
+func (r *ShipmentsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"shipment_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *ShipmentsRow) Key() ShipmentsKey {

--- a/internal/codegen/databasecodegen/testdata/7.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/7.sql.database.go
@@ -126,6 +126,23 @@ func (r *ShippersRow) MutateColumns(columns []string) (string, []string, []inter
 	return "shippers", columns, values
 }
 
+func (r *ShippersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.RevisionId.IsNull() {
+		columns = append(columns, "revision_id")
+	}
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *ShippersRow) Key() ShippersKey {
 	return ShippersKey{
 		ShipperId:  r.ShipperId,

--- a/internal/examples/freightdb/database_gen.go
+++ b/internal/examples/freightdb/database_gen.go
@@ -115,6 +115,20 @@ func (r *ShippersRow) MutateColumns(columns []string) (string, []string, []inter
 	return "shippers", columns, values
 }
 
+func (r *ShippersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *ShippersRow) Key() ShippersKey {
 	return ShippersKey{
 		ShipperId: r.ShipperId,
@@ -267,6 +281,30 @@ func (r *SitesRow) MutateColumns(columns []string) (string, []string, []interfac
 		}
 	}
 	return "sites", columns, values
+}
+
+func (r *SitesRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"site_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	if !r.DisplayName.IsNull() {
+		columns = append(columns, "display_name")
+	}
+	if !r.Latitude.IsNull() {
+		columns = append(columns, "latitude")
+	}
+	if !r.Longitude.IsNull() {
+		columns = append(columns, "longitude")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *SitesRow) Key() SitesKey {
@@ -465,6 +503,39 @@ func (r *ShipmentsRow) MutateColumns(columns []string) (string, []string, []inte
 	return "shipments", columns, values
 }
 
+func (r *ShipmentsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"shipment_id",
+		"create_time",
+		"update_time",
+	)
+	if !r.DeleteTime.IsNull() {
+		columns = append(columns, "delete_time")
+	}
+	if !r.OriginSiteId.IsNull() {
+		columns = append(columns, "origin_site_id")
+	}
+	if !r.DestinationSiteId.IsNull() {
+		columns = append(columns, "destination_site_id")
+	}
+	if !r.PickupEarliestTime.IsNull() {
+		columns = append(columns, "pickup_earliest_time")
+	}
+	if !r.PickupLatestTime.IsNull() {
+		columns = append(columns, "pickup_latest_time")
+	}
+	if !r.DeliveryEarliestTime.IsNull() {
+		columns = append(columns, "delivery_earliest_time")
+	}
+	if !r.DeliveryLatestTime.IsNull() {
+		columns = append(columns, "delivery_latest_time")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *ShipmentsRow) Key() ShipmentsKey {
 	return ShipmentsKey{
 		ShipperId:  r.ShipperId,
@@ -607,6 +678,29 @@ func (r *LineItemsRow) MutateColumns(columns []string) (string, []string, []inte
 		}
 	}
 	return "line_items", columns, values
+}
+
+func (r *LineItemsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"shipper_id",
+		"shipment_id",
+		"line_number",
+	)
+	if !r.Title.IsNull() {
+		columns = append(columns, "title")
+	}
+	if !r.Quantity.IsNull() {
+		columns = append(columns, "quantity")
+	}
+	if !r.WeightKg.IsNull() {
+		columns = append(columns, "weight_kg")
+	}
+	if !r.VolumeM3.IsNull() {
+		columns = append(columns, "volume_m3")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *LineItemsRow) Key() LineItemsKey {

--- a/internal/examples/musicdb/database_gen.go
+++ b/internal/examples/musicdb/database_gen.go
@@ -117,6 +117,24 @@ func (r *SingersRow) MutateColumns(columns []string) (string, []string, []interf
 	return "Singers", columns, values
 }
 
+func (r *SingersRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+	)
+	if !r.FirstName.IsNull() {
+		columns = append(columns, "FirstName")
+	}
+	if !r.LastName.IsNull() {
+		columns = append(columns, "LastName")
+	}
+	if len(r.SingerInfo) != 0 {
+		columns = append(columns, "SingerInfo")
+	}
+	return r.MutateColumns(columns)
+}
+
 func (r *SingersRow) Key() SingersKey {
 	return SingersKey{
 		SingerId: r.SingerId,
@@ -210,6 +228,19 @@ func (r *AlbumsRow) MutateColumns(columns []string) (string, []string, []interfa
 		}
 	}
 	return "Albums", columns, values
+}
+
+func (r *AlbumsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+	)
+	if !r.AlbumTitle.IsNull() {
+		columns = append(columns, "AlbumTitle")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *AlbumsRow) Key() AlbumsKey {
@@ -312,6 +343,20 @@ func (r *SongsRow) MutateColumns(columns []string) (string, []string, []interfac
 		}
 	}
 	return "Songs", columns, values
+}
+
+func (r *SongsRow) MutatePresentColumns() (string, []string, []interface{}) {
+	columns := make([]string, 0, len(r.ColumnNames()))
+	columns = append(
+		columns,
+		"SingerId",
+		"AlbumId",
+		"TrackId",
+	)
+	if !r.SongName.IsNull() {
+		columns = append(columns, "SongName")
+	}
+	return r.MutateColumns(columns)
 }
 
 func (r *SongsRow) Key() SongsKey {


### PR DESCRIPTION
Context:
Spanner has a hard limit on size of a mutation that is 20k cells, the
product of rows and columns. Schemas for protobuf messages containing
oneofs could be mapped to large number of nullable fields in Spanner.

When inserting rows to this schema, the majority of these nullable
fields will not be set, and setting the column to null is equivalent to
not setting it at all. This method, not setting columns at all,
drastically lowers the number of cells mutated in a mutation.

---

This change adds `row.MutatePresentColumns` which only mutates nullable
fields that are present.

* Nullable scalars are considered present if `column.Valid == true`
* Nullable arrays are considered present if `len(column) != 0`
* Nullable bytes are considered present if `len(colum) != 0`
