### PR TITLE
chore(ci): pin go 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ~1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2.4.0
@@ -35,7 +35,7 @@ jobs:
           fail_ci_if_error: true
 
   release:
-    needs: [make]
+    needs: [ make ]
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ~1.16
 
       - name: Setup Node
         uses: actions/setup-node@v2.4.0


### PR DESCRIPTION
This is to prevent CI from bumping go version by itself.
Minor versions will still be automatically bumped.
