### PR TITLE
feat(enums): add support to transpile not equals functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/spanner v1.28.0
 	github.com/google/go-cmp v0.5.6
 	github.com/stoewer/go-strcase v1.2.0
-	go.einride.tech/aip v0.52.1
+	go.einride.tech/aip v0.53.0
 	google.golang.org/api v0.63.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.einride.tech/aip v0.52.1 h1:Laz11BlCQPT+cg2iiNj/4lrFt0+Bo2d/LVdI4Q8FNUQ=
-go.einride.tech/aip v0.52.1/go.mod h1:LpASAVZqkSncCFd6p9xD15Cwn1gcWDQUppEX9q6J7Pg=
+go.einride.tech/aip v0.53.0 h1:sGrDRgce9ImVZ08RlqujnAMBy2gTs/Cj4g+sW5pwnkw=
+go.einride.tech/aip v0.53.0/go.mod h1:LpASAVZqkSncCFd6p9xD15Cwn1gcWDQUppEX9q6J7Pg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/spanfiltering/transpile_test.go
+++ b/spanfiltering/transpile_test.go
@@ -53,6 +53,19 @@ func TestTranspileFilter(t *testing.T) {
 		},
 
 		{
+			name:   "string negated equality",
+			filter: `author != "Karin Boye"`,
+			declarations: []filtering.DeclarationOption{
+				filtering.DeclareStandardFunctions(),
+				filtering.DeclareIdent("author", filtering.TypeString),
+			},
+			expectedSQL: `(author != @param_0)`,
+			expectedParams: map[string]interface{}{
+				"param_0": "Karin Boye",
+			},
+		},
+
+		{
 			name:   "timestamp",
 			filter: `create_time > timestamp("2021-02-14T14:49:34+01:00")`,
 			declarations: []filtering.DeclarationOption{
@@ -72,6 +85,18 @@ func TestTranspileFilter(t *testing.T) {
 				filtering.DeclareEnumIdent("example_enum", syntaxv1.Enum(0).Type()),
 			},
 			expectedSQL: `(example_enum = @param_0)`,
+			expectedParams: map[string]interface{}{
+				"param_0": int64(1),
+			},
+		},
+
+		{
+			name:   "enum negated equality",
+			filter: `example_enum != ENUM_ONE`,
+			declarations: []filtering.DeclarationOption{
+				filtering.DeclareEnumIdent("example_enum", syntaxv1.Enum(0).Type()),
+			},
+			expectedSQL: `(example_enum != @param_0)`,
 			expectedParams: map[string]interface{}{
 				"param_0": int64(1),
 			},

--- a/spanfiltering/transpiler.go
+++ b/spanfiltering/transpiler.go
@@ -87,6 +87,8 @@ func (t *Transpiler) transpileCallExpr(e *expr.Expr) (spansql.Expr, error) {
 		return t.transpileHasCallExpr(e)
 	case filtering.FunctionEquals:
 		return t.transpileComparisonCallExpr(e, spansql.Eq)
+	case filtering.FunctionNotEquals:
+		return t.transpileComparisonCallExpr(e, spansql.Ne)
 	case filtering.FunctionLessThan:
 		return t.transpileComparisonCallExpr(e, spansql.Lt)
 	case filtering.FunctionLessEquals:


### PR DESCRIPTION
Previously we were missing the option to transpile not equals to spansql. This PR adds that support﻿
