### PR TITLE
feat: do not run interleaved queries with empty keys

### DIFF
--- a/internal/codegen/databasecodegen/testdata/2.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/2.sql.database.go
@@ -8,6 +8,7 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
@@ -665,7 +666,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	query readInterleavedSingersRowsQuery,
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
-	if query.Albums {
+	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
 			k := SingersKey{

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -8,6 +8,7 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
@@ -922,7 +923,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
 	interleavedAlbums := make(map[AlbumsKey]*AlbumsRow)
-	if query.Albums {
+	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
 			k := SingersKey{
@@ -935,7 +936,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 			return nil, err
 		}
 	}
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{
 				SingerId: row.SingerId,
@@ -1146,7 +1147,7 @@ func (t ReadTransaction) readInterleavedAlbumsRows(
 	query readInterleavedAlbumsRowsQuery,
 ) (*readInterleavedAlbumsRowsResult, error) {
 	var r readInterleavedAlbumsRowsResult
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Songs = make(map[AlbumsKey][]*SongsRow)
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -8,6 +8,7 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
@@ -1188,7 +1189,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
 	interleavedAlbums := make(map[AlbumsKey]*AlbumsRow)
-	if query.Albums {
+	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
 			k := SingersKey{
@@ -1201,7 +1202,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 			return nil, err
 		}
 	}
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{
 				SingerId: row.SingerId,
@@ -1215,7 +1216,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 			return nil, err
 		}
 	}
-	if query.Singles {
+	if query.Singles && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Singles = make(map[SingersKey][]*SinglesRow)
 		if err := t.ReadSinglesRows(ctx, query.KeySet).Do(func(row *SinglesRow) error {
 			k := SingersKey{
@@ -1424,7 +1425,7 @@ func (t ReadTransaction) readInterleavedAlbumsRows(
 	query readInterleavedAlbumsRowsQuery,
 ) (*readInterleavedAlbumsRowsResult, error) {
 	var r readInterleavedAlbumsRowsResult
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Songs = make(map[AlbumsKey][]*SongsRow)
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{

--- a/internal/codegen/databasecodegen/testdata/6.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/6.sql.database.go
@@ -8,6 +8,7 @@ package testdata
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -700,7 +701,7 @@ func (t ReadTransaction) readInterleavedShippersRows(
 	query readInterleavedShippersRowsQuery,
 ) (*readInterleavedShippersRowsResult, error) {
 	var r readInterleavedShippersRowsResult
-	if query.Shipments {
+	if query.Shipments && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Shipments = make(map[ShippersKey][]*ShipmentsRow)
 		if err := t.ReadShipmentsRows(ctx, query.KeySet).Do(func(row *ShipmentsRow) error {
 			k := ShippersKey{

--- a/internal/examples/freightdb/database_gen.go
+++ b/internal/examples/freightdb/database_gen.go
@@ -5,6 +5,7 @@ package freightdb
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -1388,7 +1389,7 @@ func (t ReadTransaction) readInterleavedShippersRows(
 ) (*readInterleavedShippersRowsResult, error) {
 	var r readInterleavedShippersRowsResult
 	interleavedShipments := make(map[ShipmentsKey]*ShipmentsRow)
-	if query.Shipments {
+	if query.Shipments && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Shipments = make(map[ShippersKey][]*ShipmentsRow)
 		if err := t.ReadShipmentsRows(ctx, query.KeySet).Do(func(row *ShipmentsRow) error {
 			k := ShippersKey{
@@ -1401,7 +1402,7 @@ func (t ReadTransaction) readInterleavedShippersRows(
 			return nil, err
 		}
 	}
-	if query.LineItems {
+	if query.LineItems && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadLineItemsRows(ctx, query.KeySet).Do(func(row *LineItemsRow) error {
 			k := ShipmentsKey{
 				ShipperId:  row.ShipperId,
@@ -1744,7 +1745,7 @@ func (t ReadTransaction) readInterleavedShipmentsRows(
 	query readInterleavedShipmentsRowsQuery,
 ) (*readInterleavedShipmentsRowsResult, error) {
 	var r readInterleavedShipmentsRowsResult
-	if query.LineItems {
+	if query.LineItems && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.LineItems = make(map[ShipmentsKey][]*LineItemsRow)
 		if err := t.ReadLineItemsRows(ctx, query.KeySet).Do(func(row *LineItemsRow) error {
 			k := ShipmentsKey{

--- a/internal/examples/musicdb/database_gen.go
+++ b/internal/examples/musicdb/database_gen.go
@@ -5,6 +5,7 @@ package musicdb
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
@@ -919,7 +920,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
 	interleavedAlbums := make(map[AlbumsKey]*AlbumsRow)
-	if query.Albums {
+	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
 			k := SingersKey{
@@ -932,7 +933,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 			return nil, err
 		}
 	}
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{
 				SingerId: row.SingerId,
@@ -1143,7 +1144,7 @@ func (t ReadTransaction) readInterleavedAlbumsRows(
 	query readInterleavedAlbumsRowsQuery,
 ) (*readInterleavedAlbumsRowsResult, error) {
 	var r readInterleavedAlbumsRowsResult
-	if query.Songs {
+	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Songs = make(map[AlbumsKey][]*SongsRow)
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
 			k := AlbumsKey{


### PR DESCRIPTION
If the user attempts to call a generated List method without supplying a key (with the purpose of returning the entire table), we get an empty slice as a reply if no data exists in the database.
If the same is done on a table which has a interleaved child and the user asks for interleaved data by setting the RowsQuery field to true, we attempt to perform a query on the interleaved table without having a key to perform such a query (since there is no data returned from the parent List) and we get back an `Unimplemented` error from the spanner library with the error message `Cloud Spanner does not support reading no keys`.

This fix makes it so that if the list query returned no keys, we do not query the interleaved child table and just return an empty slice
