### PR TITLE
feat(spantest): decrease sleep duration from 1 second to 100 milliseconds

### DIFF
--- a/spantest/emulator.go
+++ b/spantest/emulator.go
@@ -74,7 +74,7 @@ func NewEmulatorFixture(t *testing.T) Fixture {
 		t.Log("using emulator from environment")
 	}
 	t.Log("emulator host:", emulatorHost)
-	awaitReachable(t, emulatorHost, 1*time.Second, 10*time.Second)
+	awaitReachable(t, emulatorHost, 100*time.Millisecond, 10*time.Second)
 	conn, err := grpc.DialContext(
 		ctx,
 		emulatorHost,


### PR DESCRIPTION
To decrease waiting for the container to be reported as ready, as today we could be waiting an extra second before our tests run.