### PR TITLE
feat: add json support

### DIFF
--- a/internal/codegen/typescodegen/types.go
+++ b/internal/codegen/typescodegen/types.go
@@ -97,6 +97,15 @@ func GoType(column *spanddl.Column) reflect.Type {
 		default:
 			return reflect.TypeOf(spanner.NullTime{})
 		}
+	case spansql.JSON:
+		switch {
+		case column.Type.Array:
+			return reflect.TypeOf([]spanner.NullJSON(nil))
+		case column.NotNull:
+			return reflect.TypeOf(spanner.NullJSON{})
+		default:
+			return reflect.TypeOf(spanner.NullJSON{})
+		}
 	case spansql.Numeric:
 		panic("TODO: implement support for NUMERIC")
 	default:

--- a/internal/examples/freightdb/database_gen.go
+++ b/internal/examples/freightdb/database_gen.go
@@ -145,6 +145,7 @@ type SitesRow struct {
 	DisplayName spanner.NullString  `spanner:"display_name"`
 	Latitude    spanner.NullFloat64 `spanner:"latitude"`
 	Longitude   spanner.NullFloat64 `spanner:"longitude"`
+	Config      spanner.NullJSON    `spanner:"config"`
 }
 
 func (*SitesRow) ColumnNames() []string {
@@ -157,6 +158,7 @@ func (*SitesRow) ColumnNames() []string {
 		"display_name",
 		"latitude",
 		"longitude",
+		"config",
 	}
 }
 
@@ -170,6 +172,7 @@ func (*SitesRow) ColumnIDs() []spansql.ID {
 		"display_name",
 		"latitude",
 		"longitude",
+		"config",
 	}
 }
 
@@ -183,6 +186,7 @@ func (*SitesRow) ColumnExprs() []spansql.Expr {
 		spansql.ID("display_name"),
 		spansql.ID("latitude"),
 		spansql.ID("longitude"),
+		spansql.ID("config"),
 	}
 }
 
@@ -234,6 +238,10 @@ func (r *SitesRow) UnmarshalSpannerRow(row *spanner.Row) error {
 			if err := row.Column(i, &r.Longitude); err != nil {
 				return fmt.Errorf("unmarshal sites row: longitude column: %w", err)
 			}
+		case "config":
+			if err := row.Column(i, &r.Config); err != nil {
+				return fmt.Errorf("unmarshal sites row: config column: %w", err)
+			}
 		default:
 			return fmt.Errorf("unmarshal sites row: unhandled column: %s", row.ColumnName(i))
 		}
@@ -251,6 +259,7 @@ func (r *SitesRow) Mutate() (string, []string, []interface{}) {
 		r.DisplayName,
 		r.Latitude,
 		r.Longitude,
+		r.Config,
 	}
 }
 
@@ -277,6 +286,8 @@ func (r *SitesRow) MutateColumns(columns []string) (string, []string, []interfac
 			values = append(values, r.Latitude)
 		case "longitude":
 			values = append(values, r.Longitude)
+		case "config":
+			values = append(values, r.Config)
 		default:
 			panic(fmt.Errorf("table sites does not have column %s", column))
 		}
@@ -304,6 +315,9 @@ func (r *SitesRow) MutatePresentColumns() (string, []string, []interface{}) {
 	}
 	if !r.Longitude.IsNull() {
 		columns = append(columns, "longitude")
+	}
+	if !r.Config.IsNull() {
+		columns = append(columns, "config")
 	}
 	return r.MutateColumns(columns)
 }

--- a/internal/examples/freightdb/descriptor_gen.go
+++ b/internal/examples/freightdb/descriptor_gen.go
@@ -88,6 +88,12 @@ var descriptor = databaseDescriptor{
 			notNull:              false,
 			allowCommitTimestamp: false,
 		},
+		config: columnDescriptor{
+			columnID:             "config",
+			columnType:           spansql.Type{Array: false, Base: 8, Len: 0},
+			notNull:              false,
+			allowCommitTimestamp: false,
+		},
 	},
 	shipments: shipmentsTableDescriptor{
 		tableID: "shipments",
@@ -320,6 +326,7 @@ type SitesTableDescriptor interface {
 	DisplayName() ColumnDescriptor
 	Latitude() ColumnDescriptor
 	Longitude() ColumnDescriptor
+	Config() ColumnDescriptor
 }
 
 type sitesTableDescriptor struct {
@@ -332,6 +339,7 @@ type sitesTableDescriptor struct {
 	displayName columnDescriptor
 	latitude    columnDescriptor
 	longitude   columnDescriptor
+	config      columnDescriptor
 }
 
 func (d *sitesTableDescriptor) TableName() string {
@@ -352,6 +360,7 @@ func (d *sitesTableDescriptor) ColumnNames() []string {
 		"display_name",
 		"latitude",
 		"longitude",
+		"config",
 	}
 }
 
@@ -365,6 +374,7 @@ func (d *sitesTableDescriptor) ColumnIDs() []spansql.ID {
 		"display_name",
 		"latitude",
 		"longitude",
+		"config",
 	}
 }
 
@@ -378,6 +388,7 @@ func (d *sitesTableDescriptor) ColumnExprs() []spansql.Expr {
 		spansql.ID("display_name"),
 		spansql.ID("latitude"),
 		spansql.ID("longitude"),
+		spansql.ID("config"),
 	}
 }
 
@@ -411,6 +422,10 @@ func (d *sitesTableDescriptor) Latitude() ColumnDescriptor {
 
 func (d *sitesTableDescriptor) Longitude() ColumnDescriptor {
 	return &d.longitude
+}
+
+func (d *sitesTableDescriptor) Config() ColumnDescriptor {
+	return &d.config
 }
 
 type ShipmentsTableDescriptor interface {

--- a/testdata/migrations/freight/000002_sites.up.sql
+++ b/testdata/migrations/freight/000002_sites.up.sql
@@ -7,4 +7,5 @@ CREATE TABLE sites (
     display_name STRING(63),
     latitude FLOAT64,
     longitude FLOAT64,
+    config JSON,
 ) PRIMARY KEY(shipper_id, site_id);


### PR DESCRIPTION
Currently doesn't support JSON and we cannot generate code if a spanner column has the JSON type. 

This fix adds JSON support and ensures that we can have columns with the JSON type.