### PR TITLE
feat(spantest): support offline mode

### DIFF
--- a/spantest/emulator.go
+++ b/spantest/emulator.go
@@ -58,7 +58,9 @@ func NewEmulatorFixture(t testing.TB) Fixture {
 			t.Fatal("Docker is available, but the daemon does not seem to be running.")
 		}
 		const cloudSpannerEmulatorImage = "gcr.io/cloud-spanner-emulator/emulator:latest"
-		dockerPull(t, cloudSpannerEmulatorImage)
+		if _, ok := os.LookupEnv("SPANNER_EMULATOR_SKIP_PULL"); !ok {
+			dockerPull(t, cloudSpannerEmulatorImage)
+		}
 		var containerID string
 		if isRunningOnCloudBuild(t) {
 			containerID = dockerRunDetached(t, "--network", "cloudbuild", "--publish-all", cloudSpannerEmulatorImage)


### PR DESCRIPTION
Set SPANNER_EMULATOR_SKIP_PULL to avoid pulling the spantest image
before launching. This makes it possible to run the tests without
internet connectivity.