### PR TITLE
feat(spantest): support bench and fuzz tests

### DIFF
--- a/internal/codegen/databasecodegen/goldenfile_test.go
+++ b/internal/codegen/databasecodegen/goldenfile_test.go
@@ -2,7 +2,7 @@ package databasecodegen
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -23,7 +23,7 @@ func runGoldenFileTest(t *testing.T, name string, fn func(*spanddl.Database, *co
 		testdataFile := testdataFile
 		t.Run(fmt.Sprintf("%s/%s", name, testdataFile), func(t *testing.T) {
 			t.Parallel()
-			testdata, err := ioutil.ReadFile(testdataFile)
+			testdata, err := os.ReadFile(testdataFile)
 			assert.NilError(t, err)
 			ddl, err := spansql.ParseDDL(testdataFile, string(testdata))
 			assert.NilError(t, err)

--- a/internal/codegen/descriptorcodegen/goldenfile_test.go
+++ b/internal/codegen/descriptorcodegen/goldenfile_test.go
@@ -2,7 +2,7 @@ package descriptorcodegen
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -23,7 +23,7 @@ func runGoldenFileTest(t *testing.T, name string, fn func(*spanddl.Database, *co
 		testdataFile := testdataFile
 		t.Run(fmt.Sprintf("%s/%s", name, testdataFile), func(t *testing.T) {
 			t.Parallel()
-			testdata, err := ioutil.ReadFile(testdataFile)
+			testdata, err := os.ReadFile(testdataFile)
 			assert.NilError(t, err)
 			ddl, err := spansql.ParseDDL(testdataFile, string(testdata))
 			assert.NilError(t, err)

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"cloud.google.com/go/spanner/spansql"
@@ -30,7 +30,7 @@ func (c *DatabaseConfig) LoadDatabase() (*spanddl.Database, error) {
 			return nil, fmt.Errorf("load database %s: %w", c.Name, err)
 		}
 		for _, schemaFile := range schemaFiles {
-			schema, err := ioutil.ReadFile(schemaFile)
+			schema, err := os.ReadFile(schemaFile)
 			if err != nil {
 				return nil, fmt.Errorf("load database %s: %w", c.Name, err)
 			}

--- a/internal/protoloader/loader.go
+++ b/internal/protoloader/loader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +16,7 @@ import (
 )
 
 func LoadFilesFromGoPackage(goPackage string) (*protoregistry.Files, error) {
-	tmpDir, err := ioutil.TempDir(".", "protoloader*")
+	tmpDir, err := os.MkdirTemp(".", "protoloader*")
 	if err != nil {
 		return nil, fmt.Errorf("load proto files from Go package %s: %w", goPackage, err)
 	}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func main() {
 		if err != nil {
 			log.Panic(err)
 		}
-		if err := ioutil.WriteFile(filename, content, 0o600); err != nil {
+		if err := os.WriteFile(filename, content, 0o600); err != nil {
 			log.Panic(err)
 		}
 		log.Println("wrote:", filename)
@@ -86,7 +85,7 @@ func main() {
 			if err != nil {
 				log.Panic(err)
 			}
-			if err := ioutil.WriteFile(filename, content, 0o600); err != nil {
+			if err := os.WriteFile(filename, content, 0o600); err != nil {
 				log.Panic(err)
 			}
 			log.Println("wrote:", filename)

--- a/spanddl/database_example_test.go
+++ b/spanddl/database_example_test.go
@@ -2,7 +2,7 @@ package spanddl_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"cloud.google.com/go/spanner/spansql"
@@ -16,7 +16,7 @@ func ExampleDatabase() {
 		panic(err) // TODO: Handle error.
 	}
 	for _, file := range files {
-		fileContent, err := ioutil.ReadFile(file)
+		fileContent, err := os.ReadFile(file)
 		if err != nil {
 			panic(err) // TODO: Handle error.
 		}

--- a/spantest/emulator.go
+++ b/spantest/emulator.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -131,7 +130,7 @@ func (fx *EmulatorFixture) NewDatabaseFromDDLFiles(t *testing.T, globs ...string
 	}
 	var statements []string
 	for _, file := range files {
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		assert.NilError(t, err)
 		ddl, err := spansql.ParseDDL(file, string(content))
 		assert.NilError(t, err)

--- a/spantest/fixture.go
+++ b/spantest/fixture.go
@@ -9,7 +9,7 @@ import (
 // Fixture is a Spanner test fixture.
 type Fixture interface {
 	// NewDatabaseFromDLLFiles creates a new database and applies the DDL files from the provided glob.
-	NewDatabaseFromDDLFiles(t *testing.T, globs ...string) *spanner.Client
+	NewDatabaseFromDDLFiles(t testing.TB, globs ...string) *spanner.Client
 	// NewDatabaseFromStatements creates a new database and applies the provided DLL statements.
-	NewDatabaseFromStatements(t *testing.T, statements []string) *spanner.Client
+	NewDatabaseFromStatements(t testing.TB, statements []string) *spanner.Client
 }

--- a/spantest/inmemory.go
+++ b/spantest/inmemory.go
@@ -3,8 +3,8 @@ package spantest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -46,7 +46,7 @@ func (fx *InMemoryFixture) NewDatabaseFromDDLFiles(t *testing.T, globs ...string
 	}
 	var statements []string
 	for _, file := range files {
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		assert.NilError(t, err)
 		ddl, err := spansql.ParseDDL(file, string(content))
 		assert.NilError(t, err)

--- a/spantest/inmemory.go
+++ b/spantest/inmemory.go
@@ -24,19 +24,21 @@ type InMemoryFixture struct {
 }
 
 // NewInMemoryFixture creates a test fixture for the in-memory Spanner emulator.
-func NewInMemoryFixture(t *testing.T) Fixture {
+func NewInMemoryFixture(t testing.TB) Fixture {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	if deadline, ok := t.Deadline(); ok {
-		ctx, cancel = context.WithDeadline(ctx, deadline)
-		t.Cleanup(cancel)
+	if tt, ok := t.(*testing.T); ok {
+		if deadline, ok := tt.Deadline(); ok {
+			ctx, cancel = context.WithDeadline(ctx, deadline)
+			t.Cleanup(cancel)
+		}
 	}
 	return &InMemoryFixture{ctx: ctx}
 }
 
 // NewDatabaseFromDDLFiles implements Fixture.
-func (fx *InMemoryFixture) NewDatabaseFromDDLFiles(t *testing.T, globs ...string) *spanner.Client {
+func (fx *InMemoryFixture) NewDatabaseFromDDLFiles(t testing.TB, globs ...string) *spanner.Client {
 	t.Helper()
 	var files []string
 	for _, glob := range globs {
@@ -59,7 +61,7 @@ func (fx *InMemoryFixture) NewDatabaseFromDDLFiles(t *testing.T, globs ...string
 }
 
 // NewDatabaseFromDDLFiles implements Fixture.
-func (fx *InMemoryFixture) NewDatabaseFromStatements(t *testing.T, statements []string) *spanner.Client {
+func (fx *InMemoryFixture) NewDatabaseFromStatements(t testing.TB, statements []string) *spanner.Client {
 	t.Helper()
 	const (
 		projectID  = "spanner-aip-go"


### PR DESCRIPTION
Change all functions to take `testing.TB` instead of `*testing.T` as
arguments.

This makes it possible to provide `*testing.B` for benchmark tests, and
`*testing.F` for fuzz tests.

@odsod @ericwenn as this changes the interface, should we consider this a breaking change? `testing.TB` is more limited than `*testing.T`, but all usages in this package is covered by `testing.TB` so I don't think it is a breaking change. But I could introduce a separate interface 🤷 