### PR TITLE
perf(databasegen): read interleaved tables in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/stoewer/go-strcase v1.2.0
 	go.einride.tech/aip v0.59.1
+	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.101.0
 	google.golang.org/genproto v0.0.0-20221018160656-63c7b68cfc55
 	google.golang.org/grpc v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -922,7 +922,8 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	query readInterleavedSingersRowsQuery,
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
-	interleavedAlbums := make(map[AlbumsKey]*AlbumsRow)
+	interleavedAlbumsLookup := make(map[AlbumsKey]*AlbumsRow)
+	interleavedSongs := make([]*SongsRow, 0)
 	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
@@ -930,7 +931,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 				SingerId: row.SingerId,
 			}
 			r.Albums[k] = append(r.Albums[k], row)
-			interleavedAlbums[row.Key()] = row
+			interleavedAlbumsLookup[row.Key()] = row
 			return nil
 		}); err != nil {
 			return nil, err
@@ -938,16 +939,19 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	}
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			k := AlbumsKey{
-				SingerId: row.SingerId,
-				AlbumId:  row.AlbumId,
-			}
-			if p, ok := interleavedAlbums[k]; ok {
-				p.Songs = append(p.Songs, row)
-			}
+			interleavedSongs = append(interleavedSongs, row)
 			return nil
 		}); err != nil {
 			return nil, err
+		}
+	}
+	for _, row := range interleavedSongs {
+		k := AlbumsKey{
+			SingerId: row.SingerId,
+			AlbumId:  row.AlbumId,
+		}
+		if p, ok := interleavedAlbumsLookup[k]; ok {
+			p.Songs = append(p.Songs, row)
 		}
 	}
 	return &r, nil

--- a/internal/codegen/databasecodegen/testdata/3.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/3.sql.database.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 )
 
@@ -924,26 +925,36 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	var r readInterleavedSingersRowsResult
 	interleavedAlbumsLookup := make(map[AlbumsKey]*AlbumsRow)
 	interleavedSongs := make([]*SongsRow, 0)
+	group, groupCtx := errgroup.WithContext(ctx)
 	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
-		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
-			k := SingersKey{
-				SingerId: row.SingerId,
+		group.Go(func() error {
+			if err := t.ReadAlbumsRows(groupCtx, query.KeySet).Do(func(row *AlbumsRow) error {
+				k := SingersKey{
+					SingerId: row.SingerId,
+				}
+				r.Albums[k] = append(r.Albums[k], row)
+				interleavedAlbumsLookup[row.Key()] = row
+				return nil
+			}); err != nil {
+				return err
 			}
-			r.Albums[k] = append(r.Albums[k], row)
-			interleavedAlbumsLookup[row.Key()] = row
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
 	}
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
-		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			interleavedSongs = append(interleavedSongs, row)
+		group.Go(func() error {
+			if err := t.ReadSongsRows(groupCtx, query.KeySet).Do(func(row *SongsRow) error {
+				interleavedSongs = append(interleavedSongs, row)
+				return nil
+			}); err != nil {
+				return err
+			}
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	for _, row := range interleavedSongs {
 		k := AlbumsKey{
@@ -1151,18 +1162,25 @@ func (t ReadTransaction) readInterleavedAlbumsRows(
 	query readInterleavedAlbumsRowsQuery,
 ) (*readInterleavedAlbumsRowsResult, error) {
 	var r readInterleavedAlbumsRowsResult
+	group, groupCtx := errgroup.WithContext(ctx)
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Songs = make(map[AlbumsKey][]*SongsRow)
-		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			k := AlbumsKey{
-				SingerId: row.SingerId,
-				AlbumId:  row.AlbumId,
+		group.Go(func() error {
+			if err := t.ReadSongsRows(groupCtx, query.KeySet).Do(func(row *SongsRow) error {
+				k := AlbumsKey{
+					SingerId: row.SingerId,
+					AlbumId:  row.AlbumId,
+				}
+				r.Songs[k] = append(r.Songs[k], row)
+				return nil
+			}); err != nil {
+				return err
 			}
-			r.Songs[k] = append(r.Songs[k], row)
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	return &r, nil
 }

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -1188,7 +1188,8 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	query readInterleavedSingersRowsQuery,
 ) (*readInterleavedSingersRowsResult, error) {
 	var r readInterleavedSingersRowsResult
-	interleavedAlbums := make(map[AlbumsKey]*AlbumsRow)
+	interleavedAlbumsLookup := make(map[AlbumsKey]*AlbumsRow)
+	interleavedSongs := make([]*SongsRow, 0)
 	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
 		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
@@ -1196,7 +1197,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 				SingerId: row.SingerId,
 			}
 			r.Albums[k] = append(r.Albums[k], row)
-			interleavedAlbums[row.Key()] = row
+			interleavedAlbumsLookup[row.Key()] = row
 			return nil
 		}); err != nil {
 			return nil, err
@@ -1204,13 +1205,7 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	}
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			k := AlbumsKey{
-				SingerId: row.SingerId,
-				AlbumId:  row.AlbumId,
-			}
-			if p, ok := interleavedAlbums[k]; ok {
-				p.Songs = append(p.Songs, row)
-			}
+			interleavedSongs = append(interleavedSongs, row)
 			return nil
 		}); err != nil {
 			return nil, err
@@ -1226,6 +1221,15 @@ func (t ReadTransaction) readInterleavedSingersRows(
 			return nil
 		}); err != nil {
 			return nil, err
+		}
+	}
+	for _, row := range interleavedSongs {
+		k := AlbumsKey{
+			SingerId: row.SingerId,
+			AlbumId:  row.AlbumId,
+		}
+		if p, ok := interleavedAlbumsLookup[k]; ok {
+			p.Songs = append(p.Songs, row)
 		}
 	}
 	return &r, nil

--- a/internal/codegen/databasecodegen/testdata/4.sql.database.go
+++ b/internal/codegen/databasecodegen/testdata/4.sql.database.go
@@ -12,6 +12,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/spansql"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 )
 
@@ -1190,38 +1191,51 @@ func (t ReadTransaction) readInterleavedSingersRows(
 	var r readInterleavedSingersRowsResult
 	interleavedAlbumsLookup := make(map[AlbumsKey]*AlbumsRow)
 	interleavedSongs := make([]*SongsRow, 0)
+	group, groupCtx := errgroup.WithContext(ctx)
 	if query.Albums && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Albums = make(map[SingersKey][]*AlbumsRow)
-		if err := t.ReadAlbumsRows(ctx, query.KeySet).Do(func(row *AlbumsRow) error {
-			k := SingersKey{
-				SingerId: row.SingerId,
+		group.Go(func() error {
+			if err := t.ReadAlbumsRows(groupCtx, query.KeySet).Do(func(row *AlbumsRow) error {
+				k := SingersKey{
+					SingerId: row.SingerId,
+				}
+				r.Albums[k] = append(r.Albums[k], row)
+				interleavedAlbumsLookup[row.Key()] = row
+				return nil
+			}); err != nil {
+				return err
 			}
-			r.Albums[k] = append(r.Albums[k], row)
-			interleavedAlbumsLookup[row.Key()] = row
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
 	}
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
-		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			interleavedSongs = append(interleavedSongs, row)
+		group.Go(func() error {
+			if err := t.ReadSongsRows(groupCtx, query.KeySet).Do(func(row *SongsRow) error {
+				interleavedSongs = append(interleavedSongs, row)
+				return nil
+			}); err != nil {
+				return err
+			}
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
 	}
 	if query.Singles && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Singles = make(map[SingersKey][]*SinglesRow)
-		if err := t.ReadSinglesRows(ctx, query.KeySet).Do(func(row *SinglesRow) error {
-			k := SingersKey{
-				SingerId: row.SingerId,
+		group.Go(func() error {
+			if err := t.ReadSinglesRows(groupCtx, query.KeySet).Do(func(row *SinglesRow) error {
+				k := SingersKey{
+					SingerId: row.SingerId,
+				}
+				r.Singles[k] = append(r.Singles[k], row)
+				return nil
+			}); err != nil {
+				return err
 			}
-			r.Singles[k] = append(r.Singles[k], row)
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	for _, row := range interleavedSongs {
 		k := AlbumsKey{
@@ -1429,18 +1443,25 @@ func (t ReadTransaction) readInterleavedAlbumsRows(
 	query readInterleavedAlbumsRowsQuery,
 ) (*readInterleavedAlbumsRowsResult, error) {
 	var r readInterleavedAlbumsRowsResult
+	group, groupCtx := errgroup.WithContext(ctx)
 	if query.Songs && !reflect.DeepEqual(query.KeySet, spanner.KeySets()) {
 		r.Songs = make(map[AlbumsKey][]*SongsRow)
-		if err := t.ReadSongsRows(ctx, query.KeySet).Do(func(row *SongsRow) error {
-			k := AlbumsKey{
-				SingerId: row.SingerId,
-				AlbumId:  row.AlbumId,
+		group.Go(func() error {
+			if err := t.ReadSongsRows(groupCtx, query.KeySet).Do(func(row *SongsRow) error {
+				k := AlbumsKey{
+					SingerId: row.SingerId,
+					AlbumId:  row.AlbumId,
+				}
+				r.Songs[k] = append(r.Songs[k], row)
+				return nil
+			}); err != nil {
+				return err
 			}
-			r.Songs[k] = append(r.Songs[k], row)
 			return nil
-		}); err != nil {
-			return nil, err
-		}
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 	return &r, nil
 }


### PR DESCRIPTION
Reads on interleaved tables are not dependent and can be read in
parallel. This increases throughput when reading a table including more
than one interleaved table.

---

- refactor(databasegen): make interleaved table reads independent
- perf(databasegen): perform reads on interleaved tables in parallell
