### PR TITLE
fix: don't return error on alter constraint

### DIFF
--- a/internal/examples/musicdb/descriptor_gen.go
+++ b/internal/examples/musicdb/descriptor_gen.go
@@ -11,12 +11,33 @@ func Descriptor() DatabaseDescriptor {
 }
 
 var descriptor = databaseDescriptor{
+	labels: labelsTableDescriptor{
+		tableID: "Labels",
+		labelId: columnDescriptor{
+			columnID:             "LabelId",
+			columnType:           spansql.Type{Array: false, Base: 1, Len: 0},
+			notNull:              true,
+			allowCommitTimestamp: false,
+		},
+		labelName: columnDescriptor{
+			columnID:             "LabelName",
+			columnType:           spansql.Type{Array: false, Base: 4, Len: 9223372036854775807},
+			notNull:              false,
+			allowCommitTimestamp: false,
+		},
+	},
 	singers: singersTableDescriptor{
 		tableID: "Singers",
 		singerId: columnDescriptor{
 			columnID:             "SingerId",
 			columnType:           spansql.Type{Array: false, Base: 1, Len: 0},
 			notNull:              true,
+			allowCommitTimestamp: false,
+		},
+		labelId: columnDescriptor{
+			columnID:             "LabelId",
+			columnType:           spansql.Type{Array: false, Base: 1, Len: 0},
+			notNull:              false,
 			allowCommitTimestamp: false,
 		},
 		firstName: columnDescriptor{
@@ -89,15 +110,21 @@ var descriptor = databaseDescriptor{
 }
 
 type DatabaseDescriptor interface {
+	Labels() LabelsTableDescriptor
 	Singers() SingersTableDescriptor
 	Albums() AlbumsTableDescriptor
 	Songs() SongsTableDescriptor
 }
 
 type databaseDescriptor struct {
+	labels  labelsTableDescriptor
 	singers singersTableDescriptor
 	albums  albumsTableDescriptor
 	songs   songsTableDescriptor
+}
+
+func (d *databaseDescriptor) Labels() LabelsTableDescriptor {
+	return &d.labels
 }
 
 func (d *databaseDescriptor) Singers() SingersTableDescriptor {
@@ -112,6 +139,59 @@ func (d *databaseDescriptor) Songs() SongsTableDescriptor {
 	return &d.songs
 }
 
+type LabelsTableDescriptor interface {
+	TableName() string
+	TableID() spansql.ID
+	ColumnNames() []string
+	ColumnIDs() []spansql.ID
+	ColumnExprs() []spansql.Expr
+	LabelId() ColumnDescriptor
+	LabelName() ColumnDescriptor
+}
+
+type labelsTableDescriptor struct {
+	tableID   spansql.ID
+	labelId   columnDescriptor
+	labelName columnDescriptor
+}
+
+func (d *labelsTableDescriptor) TableName() string {
+	return string(d.tableID)
+}
+
+func (d *labelsTableDescriptor) TableID() spansql.ID {
+	return d.tableID
+}
+
+func (d *labelsTableDescriptor) ColumnNames() []string {
+	return []string{
+		"LabelId",
+		"LabelName",
+	}
+}
+
+func (d *labelsTableDescriptor) ColumnIDs() []spansql.ID {
+	return []spansql.ID{
+		"LabelId",
+		"LabelName",
+	}
+}
+
+func (d *labelsTableDescriptor) ColumnExprs() []spansql.Expr {
+	return []spansql.Expr{
+		spansql.ID("LabelId"),
+		spansql.ID("LabelName"),
+	}
+}
+
+func (d *labelsTableDescriptor) LabelId() ColumnDescriptor {
+	return &d.labelId
+}
+
+func (d *labelsTableDescriptor) LabelName() ColumnDescriptor {
+	return &d.labelName
+}
+
 type SingersTableDescriptor interface {
 	TableName() string
 	TableID() spansql.ID
@@ -119,6 +199,7 @@ type SingersTableDescriptor interface {
 	ColumnIDs() []spansql.ID
 	ColumnExprs() []spansql.Expr
 	SingerId() ColumnDescriptor
+	LabelId() ColumnDescriptor
 	FirstName() ColumnDescriptor
 	LastName() ColumnDescriptor
 	SingerInfo() ColumnDescriptor
@@ -127,6 +208,7 @@ type SingersTableDescriptor interface {
 type singersTableDescriptor struct {
 	tableID    spansql.ID
 	singerId   columnDescriptor
+	labelId    columnDescriptor
 	firstName  columnDescriptor
 	lastName   columnDescriptor
 	singerInfo columnDescriptor
@@ -143,6 +225,7 @@ func (d *singersTableDescriptor) TableID() spansql.ID {
 func (d *singersTableDescriptor) ColumnNames() []string {
 	return []string{
 		"SingerId",
+		"LabelId",
 		"FirstName",
 		"LastName",
 		"SingerInfo",
@@ -152,6 +235,7 @@ func (d *singersTableDescriptor) ColumnNames() []string {
 func (d *singersTableDescriptor) ColumnIDs() []spansql.ID {
 	return []spansql.ID{
 		"SingerId",
+		"LabelId",
 		"FirstName",
 		"LastName",
 		"SingerInfo",
@@ -161,6 +245,7 @@ func (d *singersTableDescriptor) ColumnIDs() []spansql.ID {
 func (d *singersTableDescriptor) ColumnExprs() []spansql.Expr {
 	return []spansql.Expr{
 		spansql.ID("SingerId"),
+		spansql.ID("LabelId"),
 		spansql.ID("FirstName"),
 		spansql.ID("LastName"),
 		spansql.ID("SingerInfo"),
@@ -169,6 +254,10 @@ func (d *singersTableDescriptor) ColumnExprs() []spansql.Expr {
 
 func (d *singersTableDescriptor) SingerId() ColumnDescriptor {
 	return &d.singerId
+}
+
+func (d *singersTableDescriptor) LabelId() ColumnDescriptor {
+	return &d.labelId
 }
 
 func (d *singersTableDescriptor) FirstName() ColumnDescriptor {

--- a/spanddl/table.go
+++ b/spanddl/table.go
@@ -101,7 +101,8 @@ func (t *Table) applyAddConstraintAlteration(_ spansql.AddConstraint) (err error
 			err = fmt.Errorf("apply ADD CONSTRAINT: %w", err)
 		}
 	}()
-	return fmt.Errorf("TDOO: implement me")
+	// constraints are not implemented
+	return nil
 }
 
 func (t *Table) applyDropConstraintAlteration(_ spansql.DropConstraint) (err error) {
@@ -110,7 +111,8 @@ func (t *Table) applyDropConstraintAlteration(_ spansql.DropConstraint) (err err
 			err = fmt.Errorf("apply DROP CONSTRAINT: %w", err)
 		}
 	}()
-	return fmt.Errorf("TDOO: implement me")
+	// constraints are not implemented
+	return nil
 }
 
 func (t *Table) applySetOnDeleteAlteration(alteration spansql.SetOnDelete) (err error) {

--- a/testdata/migrations/music/000001_music.up.sql
+++ b/testdata/migrations/music/000001_music.up.sql
@@ -1,5 +1,11 @@
+CREATE TABLE Labels (
+   LabelId    INT64 NOT NULL,
+   LabelName  STRING(MAX),
+) PRIMARY KEY (LabelId);
+
 CREATE TABLE Singers (
   SingerId   INT64 NOT NULL,
+  LabelId    INT64,
   FirstName  STRING(1024),
   LastName   STRING(1024),
   SingerInfo BYTES(MAX),
@@ -19,3 +25,6 @@ CREATE TABLE Songs (
   SongName     STRING(MAX),
 ) PRIMARY KEY (SingerId, AlbumId, TrackId),
   INTERLEAVE IN PARENT Albums ON DELETE CASCADE;
+
+ALTER TABLE Singers
+    ADD CONSTRAINT FK_LabelSinger FOREIGN KEY (LabelId) REFERENCES Labels (LabelId);


### PR DESCRIPTION
This PR makes it so that the `applyDropConstraintAlteration` and `applyAddConstraintAlteration` no longer return errors, thus allowing us to add `CONSTRAINT`s to already existing tables. The code generation does not seem to use `CONSTRAINT`s in any way, so this change should be valid. Furthermore, it makes it more consistent with `applyCreateTable`, since that function also does not take `CONSTRAINT`s into account. 