### PR TITLE
fix: replace go release deprecaded --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,6 @@ jobs:
         if: ${{ steps.semantic-release.outputs.version != '' }}
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
seems like `--rm-dist `flag has been deprecated. Changing to `--clean` as suggested by error message here:

https://github.com/einride/spanner-aip-go/actions/runs/5485997803/jobs/9995506253