### PR TITLE
fix(spanddl): support dropping interleaved tables

### DIFF
--- a/spanddl/database_test.go
+++ b/spanddl/database_test.go
@@ -293,6 +293,37 @@ func TestDatabase_ApplyDDL(t *testing.T) {
 		},
 
 		{
+			name: "drop table with interleaved tables",
+			ddls: []string{
+				`CREATE TABLE Singers (
+				  SingerId   INT64 NOT NULL,
+				  FirstName  STRING(1024),
+				  LastName   STRING(1024),
+				  SingerInfo BYTES(MAX),
+				  BirthDate  DATE,
+				) PRIMARY KEY(SingerId);`,
+
+				`CREATE TABLE Albums (
+				  SingerId     INT64 NOT NULL,
+				  AlbumId      INT64 NOT NULL,
+				  AlbumTitle   STRING(MAX),
+				) PRIMARY KEY (SingerId, AlbumId),
+				  INTERLEAVE IN PARENT Singers ON DELETE CASCADE;`,
+
+				`CREATE TABLE Genres (
+				  SingerId     INT64 NOT NULL,
+				  GenreId      INT64 NOT NULL,
+				  GenreTitle   STRING(MAX),
+				) PRIMARY KEY (SingerId, AlbumId),
+				  INTERLEAVE IN PARENT Singers ON DELETE CASCADE;`,
+
+				`DROP TABLE Singers;`,
+			},
+			errorDdlIndex: 3,
+			errorContains: "DROP TABLE: table Singers has interleaved tables Albums, Genres",
+		},
+
+		{
 			name: "create index",
 			ddls: []string{
 				`CREATE TABLE Singers (

--- a/spanddl/database_test.go
+++ b/spanddl/database_test.go
@@ -293,6 +293,46 @@ func TestDatabase_ApplyDDL(t *testing.T) {
 		},
 
 		{
+			name: "drop interleaved",
+			ddls: []string{
+				`CREATE TABLE Singers (
+				  SingerId   INT64 NOT NULL,
+				  FirstName  STRING(1024),
+				  LastName   STRING(1024),
+				  SingerInfo BYTES(MAX),
+				  BirthDate  DATE,
+				) PRIMARY KEY(SingerId);`,
+
+				`CREATE TABLE Albums (
+				  SingerId     INT64 NOT NULL,
+				  AlbumId      INT64 NOT NULL,
+				  AlbumTitle   STRING(MAX),
+				) PRIMARY KEY (SingerId, AlbumId),
+				  INTERLEAVE IN PARENT Singers ON DELETE CASCADE;`,
+
+				`DROP TABLE Albums;`,
+			},
+			expected: &Database{
+				Tables: []*Table{
+					{
+						Name: "Singers",
+						Columns: []*Column{
+							{Name: "SingerId", Type: spansql.Type{Base: spansql.Int64}, NotNull: true},
+							{Name: "FirstName", Type: spansql.Type{Base: spansql.String, Len: 1024}},
+							{Name: "LastName", Type: spansql.Type{Base: spansql.String, Len: 1024}},
+							{Name: "SingerInfo", Type: spansql.Type{Base: spansql.Bytes, Len: spansql.MaxLen}},
+							{Name: "BirthDate", Type: spansql.Type{Base: spansql.Date}},
+						},
+						PrimaryKey: []spansql.KeyPart{
+							{Column: "SingerId"},
+						},
+						InterleavedTables: []*Table{},
+					},
+				},
+			},
+		},
+
+		{
 			name: "drop table with interleaved tables",
 			ddls: []string{
 				`CREATE TABLE Singers (

--- a/testdata/migrations/music/000002_create_drop_genres.up.sql
+++ b/testdata/migrations/music/000002_create_drop_genres.up.sql
@@ -1,0 +1,8 @@
+-- This migration should result in no schema changes.
+CREATE TABLE Genres (
+                        SingerId     INT64 NOT NULL,
+                        GenreId      INT64 NOT NULL,
+) PRIMARY KEY (SingerId, GenreId),
+  INTERLEAVE IN PARENT Singers ON DELETE CASCADE;
+
+DROP TABLE Genres;


### PR DESCRIPTION
- test(spanddl): possibility to specify expected error for ddl statement
- feat: throw error if dropping table with interleaved tables
- fix(spanddl): support dropping interleaved tables
