### PR TITLE
feat: add support for substring matching

### DIFF
--- a/spanfiltering/transpile_test.go
+++ b/spanfiltering/transpile_test.go
@@ -123,6 +123,29 @@ func TestTranspileFilter(t *testing.T) {
 			},
 			expectedSQL: `TRUE`,
 		},
+
+		{
+			name:   "substring matching",
+			filter: `author = "*Boye*"`,
+			declarations: []filtering.DeclarationOption{
+				filtering.DeclareStandardFunctions(),
+				filtering.DeclareIdent("author", filtering.TypeString),
+			},
+			expectedSQL: `(author LIKE @param_0)`,
+			expectedParams: map[string]interface{}{
+				"param_0": "%Boye%",
+			},
+		},
+
+		{
+			name:   "substring matching with '*'",
+			filter: `author = "*Bo*ye*"`,
+			declarations: []filtering.DeclarationOption{
+				filtering.DeclareStandardFunctions(),
+				filtering.DeclareIdent("author", filtering.TypeString),
+			},
+			errorContains: "wildcard only supported in leading or trailing positions",
+		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
According to the filtering BNFC spec, using the "=" operator with an RHS
starting or ending with "*" should be evaluated as substring matching.
