### PR TITLE
feat: add assert nilErr messages

### DIFF
--- a/spantest/emulator.go
+++ b/spantest/emulator.go
@@ -102,12 +102,12 @@ func NewEmulatorFixture(t testing.TB) Fixture {
 			NodeCount:   1,
 		},
 	})
-	assert.NilError(t, err)
+	assert.NilError(t, err, "failed to create instance")
 	createdInstance, err := createInstanceOp.Wait(ctx)
-	assert.NilError(t, err)
+	assert.NilError(t, err, "failed to prepare instance for serving")
 	t.Log("instance:", createdInstance.String())
 	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx, option.WithGRPCConn(conn))
-	assert.NilError(t, err)
+	assert.NilError(t, err, "failed to create database admin client")
 	return &EmulatorFixture{
 		ctx:                 ctx,
 		conn:                conn,


### PR DESCRIPTION
Having some CI issues in a repo using this, so in order to simplify debugging this PR adds some extra info to the nil error assertions done when setting up the instance and client in the emulator.