### PR TITLE
chore(codeowners): replace team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
- * @einride/transportation-platform @thall
+ * @einride/freight-control @thall


### PR DESCRIPTION
## Update CODEOWNERS
### Why?
Team Transportation was split up.
### What?
- Move ownership to `@einride/freight-control`.
### Notes
- This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
