### PR TITLE
chore(VEH-2750): add dependabot-fix make target and workflow

### DIFF
--- a/.github/workflows/dependabot-make.yaml
+++ b/.github/workflows/dependabot-make.yaml
@@ -1,0 +1,22 @@
+name: Dependabot Make Fix
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - master
+
+jobs:
+
+  call-dependabot-make-fix:
+
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    uses: einride/github-actions/.github/workflows/reusable-dependabot-make.yaml@master
+    secrets:
+      einridebot_personal_access_token: ${{ secrets.EINRIDEBOT_PERSONAL_ACCESS_TOKEN }}

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -29,6 +29,13 @@ func All(ctx context.Context) error {
 	return nil
 }
 
+func DependabotFix(ctx context.Context) error {
+	sg.Deps(ctx, FormatMarkdown, FormatYAML)
+	sg.Deps(ctx, SpannerGenerate)
+	sg.SerialDeps(ctx, GoModTidy)
+	return nil
+}
+
 func FormatYAML(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting YAML files...")
 	return sgyamlfmt.Run(ctx)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ all: $(sagefile)
 convco-check: $(sagefile)
 	@$(sagefile) ConvcoCheck
 
+.PHONY: dependabot-fix
+dependabot-fix: $(sagefile)
+	@$(sagefile) DependabotFix
+
 .PHONY: format-markdown
 format-markdown: $(sagefile)
 	@$(sagefile) FormatMarkdown


### PR DESCRIPTION
Adds the Dependabot Fix workflow presented during the June 2025 hackathon. This make target and workflow will run make commands in order to attempt to fix errors in the dependabot PRs. We've already added is successfully to all @asset-intelligence owned repositories, but please let me know if it fails and we'll try to fix it.